### PR TITLE
Add ASan/UBSan options and dedicated ASan CI test job

### DIFF
--- a/.claude/scripts/test.sh
+++ b/.claude/scripts/test.sh
@@ -19,6 +19,8 @@ docker run --rm \
   --cap-add SYS_ADMIN \
   --mount type=bind,src="$HOST_SRC",dst=/build \
   --mount type=bind,src=/usr/bin/fusermount3,dst=/usr/bin/fusermount3,readonly \
+  --mount type=bind,src=/etc/passwd,dst=/etc/passwd,readonly \
+  --security-opt label=disable \
   clang-tidy-image -c "
     /build/SimpleNetworkProtocol/build/SimpleNetworkProtocolTest $FILTER_ARG
   "

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -114,4 +114,45 @@ jobs:
                   -v ${{ github.workspace }}:/workspace \
                   -w /workspace \
                   ghcr.io/drlk/clang-tidy-image:v16 \
-                  bash -c "cd SimpleNetworkProtocol/build && CC=clang CXX=clang++ cmake -G Ninja .. && cmake --build . -- -j\$(nproc) && TSAN_OPTIONS="halt_on_error=1" ./SimpleNetworkProtocolTest"
+                  bash -c "cd SimpleNetworkProtocol/build && CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . -- -j\$(nproc) && TSAN_OPTIONS="halt_on_error=1" ./SimpleNetworkProtocolTest"
+
+    test-asan-job:
+        needs: clang-format-job
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                ref: ${{ github.head_ref }}
+                submodules: true
+
+            - name: Install and load FUSE
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y fuse3
+                sudo modprobe fuse
+
+            - name: Configure kernel network parameters
+              run: |
+                sudo sysctl -p ${{ github.workspace }}/SimpleNetworkProtocol/sysctl.conf
+                sudo tc qdisc replace dev lo root fq
+
+            - name: Login to container registry
+              uses: docker/login-action@v3
+              with:
+                registry: ghcr.io
+                username: drlk
+                password: ${{ secrets.DOCKER_CONTAINER_REGISTRY_TOKEN }}
+
+            - name: Build and Run tests with AddressSanitizer
+              run: |
+                docker run --rm \
+                  --privileged \
+                  --network=host \
+                  --device /dev/fuse \
+                  --security-opt apparmor:unconfined \
+                  --entrypoint "" \
+                  -v ${{ github.workspace }}:/workspace \
+                  -w /workspace \
+                  ghcr.io/drlk/clang-tidy-image:v16 \
+                  bash -c "cd SimpleNetworkProtocol/build && CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_TSAN=OFF -DENABLE_ASAN=ON .. && cmake --build . -- -j\$(nproc) && ASAN_OPTIONS="halt_on_error=1" UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" ./SimpleNetworkProtocolTest"

--- a/SimpleNetworkProtocol/CMakeLists.txt
+++ b/SimpleNetworkProtocol/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.25)
 option(ENABLE_PRECOMPILE_HEADERS "Enable Precompile Headers" ON)
 option(ENABLE_TRACY "Enable Tracy" OFF)
 option(ENABLE_TSAN "Enable Thread Sanitizer for tests" ON)
+option(ENABLE_ASAN "Enable Address Sanitizer for tests" OFF)
+option(ENABLE_UBSAN "Enable Undefined Behavior Sanitizer for tests" ON)
 
 project(SimpleNetworkProtocol)
 
@@ -17,7 +19,23 @@ else()
   set(TSAN_ACTIVE FALSE)
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo" AND NOT TSAN_ACTIVE)
+if(ENABLE_ASAN AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(ASAN_ACTIVE TRUE)
+else()
+  set(ASAN_ACTIVE FALSE)
+endif()
+
+if(ENABLE_UBSAN AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(UBSAN_ACTIVE TRUE)
+else()
+  set(UBSAN_ACTIVE FALSE)
+endif()
+
+if(TSAN_ACTIVE AND ASAN_ACTIVE)
+  message(FATAL_ERROR "ENABLE_TSAN and ENABLE_ASAN are mutually exclusive")
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo" AND NOT TSAN_ACTIVE AND NOT ASAN_ACTIVE AND NOT UBSAN_ACTIVE)
   add_compile_options(-flto=thin)
   add_link_options(-flto=thin)
   if(NOT CMAKE_EXE_LINKER_FLAGS MATCHES "fuse-ld")
@@ -33,6 +51,16 @@ endif()
 if(TSAN_ACTIVE)
   add_compile_options(-fsanitize=thread)
   add_link_options(-fsanitize=thread)
+endif()
+
+if(ASAN_ACTIVE)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address)
+endif()
+
+if(UBSAN_ACTIVE)
+  add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=undefined)
 endif()
 
 if(LINUX)
@@ -86,7 +114,7 @@ if(ENABLE_TESTS)
   if(LINUX)
   target_link_libraries(SimpleNetworkProtocolTest PRIVATE FileSystem)
 endif()
-  if(NOT ENABLE_TSAN)
+  if(NOT TSAN_ACTIVE AND NOT ASAN_ACTIVE AND NOT UBSAN_ACTIVE)
     target_link_options(SimpleNetworkProtocolTest
         PRIVATE
         -static-libgcc

--- a/SimpleNetworkProtocol/FileSystem/include/FileCache/Range.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/FileCache/Range.hpp
@@ -52,13 +52,25 @@ private:
     mutable std::atomic<int> _counter { 1 };
 };
 
+// Transparent comparator used by std::set<std::shared_ptr<Range>, ...> so the
+// owning containers (e.g. Leaf::_data) can keep ranges alive via shared_ptr
+// without sacrificing the natural Range ordering.
+struct RangePtrLess {
+    using is_transparent = void;
+    bool operator()(const std::shared_ptr<Range>& lhs, const std::shared_ptr<Range>& rhs) const { return *lhs < *rhs; } // NOLINT(fuchsia-overloaded-operator)
+    bool operator()(const std::shared_ptr<Range>& lhs, const Range& rhs) const { return *lhs < rhs; } // NOLINT(fuchsia-overloaded-operator)
+    bool operator()(const Range& lhs, const std::shared_ptr<Range>& rhs) const { return lhs < *rhs; } // NOLINT(fuchsia-overloaded-operator)
+};
+
 // RAII handle that unpins a set of Ranges when destroyed.
 // Constructed on the cached-tree thread (via Leaf::GetData), destroyed on the
-// disk thread when the owning ReadFileCacheJob finishes.
+// disk thread when the owning ReadFileCacheJob finishes. Owns shared_ptr to
+// keep the Range alive even if Leaf::ExtractBlock evicts the cache entry while
+// the disk thread still holds the pin.
 class RangePin {
 public:
     RangePin() = default;
-    explicit RangePin(std::vector<const Range*> ranges)
+    explicit RangePin(std::vector<std::shared_ptr<const Range>> ranges)
         : _ranges(std::move(ranges))
     {
     }
@@ -68,13 +80,13 @@ public:
     RangePin& operator=(RangePin&&) = default;
     ~RangePin()
     {
-        for (const auto* range : _ranges) {
+        for (const auto& range : _ranges) {
             range->Unpin();
         }
     }
 
 private:
-    std::vector<const Range*> _ranges;
+    std::vector<std::shared_ptr<const Range>> _ranges;
 };
 
 } // namespace FastTransport::FileSystem::FileCache

--- a/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <array>
+#include <atomic>
 #include <cassert>
+#include <cstddef>
 #include <filesystem>
 #include <fuse3/fuse_lowlevel.h>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 
@@ -50,10 +54,19 @@ public:
     FileCache::BufferView GetData(fuse_ino_t inode, off_t offset, size_t size) const;
     FileTree::Data AddData(fuse_ino_t inode, off_t offset, size_t size, Data&& data);
 
-    FreeData GetFreeData();
+    // Eviction is sharded by inode to keep all mutations of a given Leaf on the
+    // same cacheTreeQueue worker. Callers pass their own shard index (the one
+    // they were dispatched on) and only entries belonging to that shard are
+    // considered for eviction.
+    FreeData GetFreeData(size_t shardIdx);
     bool NeedsEviction() const;
 
     static constexpr int MaxCachePackets = 10000;
+    static constexpr size_t ShardCount = 4;
+    static size_t ShardForInode(fuse_ino_t inode) noexcept
+    {
+        return std::hash<fuse_ino_t> {}(inode) % ShardCount;
+    }
 
     FileCache::FileCache& GetFileCache();
     // Cancel all pending jobs across the entire file tree. Must be called after
@@ -78,8 +91,11 @@ private:
     LeafPtr _root;
     std::filesystem::path _cacheFolder;
 
-    std::unordered_map<fuse_ino_t, int> _cache;
-    int _totalCachedPackets = 0;
+    // Per-shard cache index; each shard is owned exclusively by its
+    // corresponding cacheTreeQueue worker, so no cross-shard locking is
+    // required. _grandTotal is summed across shards for NeedsEviction().
+    std::array<std::unordered_map<fuse_ino_t, int>, ShardCount> _cachePerShard;
+    std::atomic<int> _grandTotalCachedPackets { 0 };
     FileCachePtr _fileCache;
 
     void Scan(const std::filesystem::path& directoryPath, Leaf& root);

--- a/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
@@ -5,10 +5,13 @@
 #include <cassert>
 #include <cstddef>
 #include <filesystem>
-#include <fuse3/fuse_lowlevel.h>
 #include <functional>
+#include <list>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
+
+#include <fuse3/fuse_lowlevel.h>
 
 #include "FileCache/BufferView.hpp"
 #include "IPacket.hpp"
@@ -81,6 +84,13 @@ public:
     void RegisterLeaf(std::uint64_t serverInode, Leaf* leaf);
     void UnregisterLeaf(std::uint64_t serverInode);
 
+    // Park a removed Leaf whose nlookup is still > 0 so its address stays valid
+    // for the in-flight FUSE forget that the kernel will eventually deliver.
+    // The Leaf removes itself once ReleaseRef brings nlookup to zero.
+    void Tombstone(std::unique_ptr<Leaf> leaf);
+    // Called by Leaf::ReleaseRef when a tombstoned Leaf reaches nlookup == 0.
+    void RemoveTombstone(Leaf* leaf);
+
     void CancelAllPendingJobs();
 
 private:
@@ -97,6 +107,11 @@ private:
     std::array<std::unordered_map<fuse_ino_t, int>, ShardCount> _cachePerShard;
     std::atomic<int> _grandTotalCachedPackets { 0 };
     FileCachePtr _fileCache;
+
+    // Holds Leafs that have been removed from the tree but still have
+    // outstanding FUSE nlookup references. Protected by _tombstonesMutex.
+    mutable std::mutex _tombstonesMutex;
+    std::list<std::unique_ptr<Leaf>> _tombstones;
 
     void Scan(const std::filesystem::path& directoryPath, Leaf& root);
 };

--- a/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/FileTree.hpp
@@ -6,9 +6,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <functional>
-#include <list>
 #include <memory>
-#include <mutex>
 #include <unordered_map>
 
 #include <fuse3/fuse_lowlevel.h>
@@ -34,7 +32,7 @@ class Leaf;
 
 class FileTree {
     using FilePtr = std::unique_ptr<File>;
-    using LeafPtr = std::unique_ptr<Leaf>;
+    using LeafPtr = std::shared_ptr<Leaf>;
     using FileCachePtr = std::unique_ptr<FileCache::FileCache>;
 
 public:
@@ -48,6 +46,11 @@ public:
     ~FileTree();
 
     Leaf& GetRoot();
+    // Replace the root subtree (used by MergeIn after deserialising a remote
+    // tree). Caller is responsible for ensuring the index is consistent: any
+    // live Leaf* references and serverInodeIndex entries from the old root are
+    // about to dangle, so this should only be called during initialisation.
+    void SetRoot(std::shared_ptr<Leaf> root) noexcept;
     std::filesystem::path GetCacheFolder() const;
 
     static FileTree GetTestFileTree();
@@ -72,32 +75,34 @@ public:
     }
 
     FileCache::FileCache& GetFileCache();
-    // Cancel all pending jobs across the entire file tree. Must be called after
-    // stopping the scheduler (so no new jobs are being added) and before destroying
-    // the filesystem session (so fuse_reply_err can still be called).
-    Leaf* FindLeafByServerInode(std::uint64_t serverInode);
+
+    // Returns nullptr if the inode is unknown OR if the corresponding Leaf has
+    // already been destroyed (the index holds weak_ptrs, so a stale entry that
+    // somehow outlived the Leaf surfaces cleanly as expired weak_ptr instead
+    // of becoming a dangling raw pointer).
+    std::shared_ptr<Leaf> FindLeafByServerInode(std::uint64_t serverInode);
 
     // Index maintenance hooks invoked by Leaf when the tree is mutated.
     // RegisterLeaf inserts the (serverInode, leaf) pair; UnregisterLeaf removes
     // by the inode the leaf currently reports. Callers must invoke them with
     // matching pre/post values when SetServerInode rekeys an entry.
-    void RegisterLeaf(std::uint64_t serverInode, Leaf* leaf);
+    void RegisterLeaf(std::uint64_t serverInode, const std::shared_ptr<Leaf>& leaf);
     void UnregisterLeaf(std::uint64_t serverInode);
 
-    // Park a removed Leaf whose nlookup is still > 0 so its address stays valid
-    // for the in-flight FUSE forget that the kernel will eventually deliver.
-    // The Leaf removes itself once ReleaseRef brings nlookup to zero.
-    void Tombstone(std::unique_ptr<Leaf> leaf);
-    // Called by Leaf::ReleaseRef when a tombstoned Leaf reaches nlookup == 0.
-    void RemoveTombstone(Leaf* leaf);
-
+    // Cancel all pending jobs across the entire file tree. Must be called after
+    // stopping the scheduler (so no new jobs are being added) and before destroying
+    // the filesystem session (so fuse_reply_err can still be called).
     void CancelAllPendingJobs();
 
 private:
     // _serverInodeIndex must outlive _root: when ~FileTree destroys _root,
     // the cascading Leaf destructors (RemoveChild paths) still need a live
-    // index to update.
-    std::unordered_map<std::uint64_t, Leaf*> _serverInodeIndex;
+    // index to update. All mutations and lookups go through _mainQueue
+    // (single-threaded), so no locking is required — see CacheTreeJob
+    // subclasses, which only operate on shard-affine per-Leaf state.
+    // Holds weak_ptrs so a stale entry surfaces as expired-weak_ptr (clean
+    // nullptr from FindLeafByServerInode) rather than a dangling raw pointer.
+    std::unordered_map<std::uint64_t, std::weak_ptr<Leaf>> _serverInodeIndex;
     LeafPtr _root;
     std::filesystem::path _cacheFolder;
 
@@ -107,11 +112,6 @@ private:
     std::array<std::unordered_map<fuse_ino_t, int>, ShardCount> _cachePerShard;
     std::atomic<int> _grandTotalCachedPackets { 0 };
     FileCachePtr _fileCache;
-
-    // Holds Leafs that have been removed from the tree but still have
-    // outstanding FUSE nlookup references. Protected by _tombstonesMutex.
-    mutable std::mutex _tombstonesMutex;
-    std::list<std::unique_ptr<Leaf>> _tombstones;
 
     void Scan(const std::filesystem::path& directoryPath, Leaf& root);
 };

--- a/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
@@ -109,7 +109,7 @@ private:
     std::uint64_t _serverInode = 0;
     FileTree* _tree = nullptr;
 
-    std::unordered_map<size_t, std::set<FileCache::Range>> _data;
+    std::unordered_map<size_t, std::set<std::shared_ptr<FileCache::Range>, FileCache::RangePtrLess>> _data;
     std::shared_ptr<PiecesStatus> _piecesStatus;
     std::unordered_map<size_t, std::vector<std::unique_ptr<IPendingJob>>> _pendingJobs;
 };

--- a/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -56,7 +57,7 @@ public:
 
     void Rescan();
 
-    const std::map<std::string, Leaf>& GetChildren() const;
+    const std::map<std::string, std::unique_ptr<Leaf>>& GetChildren() const;
 
     std::optional<std::reference_wrapper<const Leaf>> Find(const std::string& name) const;
     // Non-const lookup — returns nullptr when not found. Read-only access by name
@@ -99,13 +100,27 @@ public:
 
     void SetTree(FileTree* tree) noexcept { _tree = tree; }
 
+    [[nodiscard]] bool IsTombstoned() const noexcept { return _isTombstoned; }
+    void MarkTombstoned() noexcept { _isTombstoned = true; }
+    [[nodiscard]] std::uint64_t GetNlookup() const noexcept { return _nlookup.load(std::memory_order_relaxed); }
+
 private:
-    std::map<std::string, Leaf> children; // TODO: use std::set
+    // True once the parent has removed this Leaf from its children map but the
+    // kernel still holds nlookup > 0 references. Set by FileTree::Tombstone()
+    // under the tree's tombstone mutex; once true, the Leaf only outlives long
+    // enough for ReleaseRef() to drain _nlookup to zero, at which point it
+    // self-removes from the tree's tombstone list.
+    bool _isTombstoned = false;
+
+    std::map<std::string, std::unique_ptr<Leaf>> children;
     std::filesystem::path _name;
     std::filesystem::file_type _type;
     uintmax_t _size;
     Leaf* _parent;
-    mutable std::uint64_t _nlookup = 0;
+    // _nlookup mirrors the kernel's reference count for this inode. AddRef on
+    // every fuse_lookup, ReleaseRef on every fuse_forget. The Leaf must stay
+    // allocated while _nlookup > 0 even if the parent map has dropped it.
+    mutable std::atomic<std::uint64_t> _nlookup { 0 };
     std::uint64_t _serverInode = 0;
     FileTree* _tree = nullptr;
 

--- a/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/Leaf.hpp
@@ -31,16 +31,24 @@ namespace FastTransport::FileSystem {
 class File;
 class FileTree;
 
-class Leaf {
+// Lifetime model: Leaf is owned by std::shared_ptr. The parent keeps a
+// shared_ptr in its `children` map. The kernel "owns" additional lookup
+// references that AddRef/ReleaseRef track via _nlookup; the very first
+// AddRef captures _selfPin = shared_from_this(), which keeps the Leaf
+// alive even after the parent's RemoveChild has dropped its shared_ptr,
+// until the matching forget(s) bring _nlookup back to zero. The last
+// ReleaseRef releases _selfPin; whichever shared_ptr is the actual last
+// reference (parent's or the pin) destroys the Leaf.
+class Leaf : public std::enable_shared_from_this<Leaf> {
     using FilePtr = std::unique_ptr<File>;
     using Data = Containers::MultiList<std::unique_ptr<Protocol::IPacket>>;
 
 public:
     Leaf(std::filesystem::path&& name, std::filesystem::file_type type, uintmax_t size, Leaf* parent);
     Leaf(const Leaf& that) = delete;
-    Leaf(Leaf&& that) noexcept;
+    Leaf(Leaf&& that) = delete;
     Leaf& operator=(const Leaf& that) = delete;
-    Leaf& operator=(Leaf&& that) noexcept;
+    Leaf& operator=(Leaf&& that) = delete;
     ~Leaf();
 
     const std::filesystem::path& GetName() const;
@@ -48,7 +56,7 @@ public:
     std::uintmax_t GetSize() const;
     bool IsDeleted() const;
     Leaf& AddChild(std::filesystem::path&& name, std::filesystem::file_type type, uintmax_t size);
-    Leaf& AddChild(Leaf&& leaf);
+    Leaf& AddChild(std::shared_ptr<Leaf> leaf);
     void RemoveChild(const std::string& name);
 
     void AddRef() const;
@@ -57,13 +65,15 @@ public:
 
     void Rescan();
 
-    const std::map<std::string, std::unique_ptr<Leaf>>& GetChildren() const;
+    const std::map<std::string, std::shared_ptr<Leaf>>& GetChildren() const;
 
     std::optional<std::reference_wrapper<const Leaf>> Find(const std::string& name) const;
-    // Non-const lookup — returns nullptr when not found. Read-only access by name
-    // for callers that walk the tree mutably; structural changes still go through
-    // AddChild/RemoveChild so the FileTree index stays consistent.
-    Leaf* FindChild(const std::string& name);
+    // Non-const lookup — returns nullptr when not found. Returns the same
+    // shared_ptr that lives in the parent's `children` map, so the caller can
+    // keep the Leaf alive past a later RemoveChild that drops the map entry.
+    // Structural changes still go through AddChild/RemoveChild so the
+    // FileTree index stays consistent.
+    std::shared_ptr<Leaf> FindChild(const std::string& name);
 
     std::filesystem::path GetFullPath() const;
     std::filesystem::path GetCachePath() const;
@@ -100,27 +110,42 @@ public:
 
     void SetTree(FileTree* tree) noexcept { _tree = tree; }
 
-    [[nodiscard]] bool IsTombstoned() const noexcept { return _isTombstoned; }
-    void MarkTombstoned() noexcept { _isTombstoned = true; }
-    [[nodiscard]] std::uint64_t GetNlookup() const noexcept { return _nlookup.load(std::memory_order_relaxed); }
+    [[nodiscard]] std::uint64_t GetNlookup() const noexcept
+    {
+        return _nlookup.load(std::memory_order_relaxed);
+    }
+
+    // Drop _selfPin on this Leaf and every descendant. Called from ~FileTree
+    // as a safety net: in normal flow each kernel forget routes through
+    // ReleaseLeafRefJob and drains _selfPin, but if the scheduler is already
+    // gone by the time the FUSE worker delivers forget, those releases are
+    // dropped and _selfPin would otherwise leak on shutdown.
+    void DropPinsRecursively() noexcept;
 
 private:
-    // True once the parent has removed this Leaf from its children map but the
-    // kernel still holds nlookup > 0 references. Set by FileTree::Tombstone()
-    // under the tree's tombstone mutex; once true, the Leaf only outlives long
-    // enough for ReleaseRef() to drain _nlookup to zero, at which point it
-    // self-removes from the tree's tombstone list.
-    bool _isTombstoned = false;
-
-    std::map<std::string, std::unique_ptr<Leaf>> children;
+    std::map<std::string, std::shared_ptr<Leaf>> children;
     std::filesystem::path _name;
     std::filesystem::file_type _type;
     uintmax_t _size;
     Leaf* _parent;
-    // _nlookup mirrors the kernel's reference count for this inode. AddRef on
-    // every fuse_lookup, ReleaseRef on every fuse_forget. The Leaf must stay
-    // allocated while _nlookup > 0 even if the parent map has dropped it.
+    // Kernel-side reference count. AddRef is called whenever we hand a
+    // newly-resolved client inode to the kernel (fuse_reply_entry from a
+    // lookup, each direntplus entry in readdirplus); ReleaseRef on the
+    // matching forget. _selfPin is a shared_ptr to this Leaf that the very
+    // first AddRef captures and the very last ReleaseRef releases — that's
+    // what keeps the Leaf alive after the parent's RemoveChild has dropped
+    // its shared_ptr but the kernel has not yet sent forget.
+    //
+    // Single-thread invariant: AddRef/ReleaseRef are only invoked from a
+    // _mainQueue worker (the response-job path that handles the FUSE message
+    // for this side — server's lookup/forget on the server, the equivalent
+    // response-in jobs on the client). The cache invalidation path
+    // (InvalidateCacheLeafJob) keeps the Leaf alive via its own shared_ptr
+    // instead of touching nlookup, so it never crosses thread boundaries
+    // here. _nlookup stays atomic only as a relaxed counter for
+    // GetNlookup() observability, not for synchronisation.
     mutable std::atomic<std::uint64_t> _nlookup { 0 };
+    mutable std::shared_ptr<const Leaf> _selfPin;
     std::uint64_t _serverInode = 0;
     FileTree* _tree = nullptr;
 

--- a/SimpleNetworkProtocol/FileSystem/include/LeafSerializer.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/LeafSerializer.hpp
@@ -20,7 +20,7 @@ public:
         const std::uint64_t size = leaf.GetChildren().size();
         stream << size;
         for (const auto& [name, child] : leaf.GetChildren()) {
-            Serialize(child, stream);
+            Serialize(*child, stream);
         }
     }
 

--- a/SimpleNetworkProtocol/FileSystem/include/LeafSerializer.hpp
+++ b/SimpleNetworkProtocol/FileSystem/include/LeafSerializer.hpp
@@ -25,7 +25,7 @@ public:
     }
 
     template <InputStream Stream>
-    static Leaf Deserialize(InputByteStream<Stream>& stream, Leaf* parent) // NOLINT(misc-no-recursion)
+    static std::shared_ptr<Leaf> Deserialize(InputByteStream<Stream>& stream, Leaf* parent) // NOLINT(misc-no-recursion)
     {
         std::filesystem::path name;
         stream >> name;
@@ -33,13 +33,13 @@ public:
         stream >> type;
         uintmax_t fileSize {};
         stream >> fileSize;
-        Leaf leaf(std::move(name), type, fileSize, parent);
+        auto leaf = std::make_shared<Leaf>(std::move(name), type, fileSize, parent);
 
         std::uint64_t size = 0;
         stream >> size;
         for (std::uint64_t i = 0; i < size; i++) {
-            Leaf childLeaf = Deserialize(stream, &leaf);
-            leaf.AddChild(std::move(childLeaf));
+            auto childLeaf = Deserialize(stream, leaf.get());
+            leaf->AddChild(std::move(childLeaf));
         }
 
         return leaf;

--- a/SimpleNetworkProtocol/FileSystem/src/FileSystem.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/FileSystem.cpp
@@ -327,8 +327,8 @@ void FileSystem::FuseReaddir(fuse_req_t req, fuse_ino_t inode, size_t size, off_
         BufferAddFile(req, &buffer, ".", currentINode);
         BufferAddFile(req, &buffer, "..", 1);
         for (const auto& [name, file] : directory.GetChildren()) {
-            auto inode = GetINode(file);
-            BufferAddFile(req, &buffer, file.GetName().c_str(), inode);
+            auto inode = GetINode(*file);
+            BufferAddFile(req, &buffer, file->GetName().c_str(), inode);
         }
 
         ReplyBufferLimited(req, buffer.p, buffer.size, off, size);

--- a/SimpleNetworkProtocol/FileSystem/src/FileSystem.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/FileSystem.cpp
@@ -154,6 +154,7 @@ void FileSystem::Start(std::stop_token stop)
 FileSystem::~FileSystem()
 {
     if (_session != nullptr) {
+        fuse_session_unmount(_session);
         fuse_session_destroy(_session);
     }
 }

--- a/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <climits>
 #include <cstddef>
 #include <filesystem>
 #include <fuse3/fuse_lowlevel.h>
@@ -30,8 +29,8 @@ FileTree::FileTree(FileTree&& that) noexcept
     : _serverInodeIndex(std::move(that._serverInodeIndex))
     , _root(std::move(that._root))
     , _cacheFolder(std::move(that._cacheFolder))
-    , _cache(std::move(that._cache))
-    , _totalCachedPackets(that._totalCachedPackets)
+    , _cachePerShard(std::move(that._cachePerShard))
+    , _grandTotalCachedPackets(that._grandTotalCachedPackets.load())
     , _fileCache(std::move(that._fileCache))
 {
     if (_root != nullptr) {
@@ -47,8 +46,8 @@ FileTree& FileTree::operator=(FileTree&& that) noexcept
     _serverInodeIndex = std::move(that._serverInodeIndex);
     _root = std::move(that._root);
     _cacheFolder = std::move(that._cacheFolder);
-    _cache = std::move(that._cache);
-    _totalCachedPackets = that._totalCachedPackets;
+    _cachePerShard = std::move(that._cachePerShard);
+    _grandTotalCachedPackets = that._grandTotalCachedPackets.load();
     _fileCache = std::move(that._fileCache);
     if (_root != nullptr) {
         _root->SetTree(this);
@@ -101,24 +100,26 @@ FileTree::Data FileTree::AddData(fuse_ino_t inode, off_t offset, size_t size, Da
     auto& leaf = inode == FUSE_ROOT_ID ? GetRoot() : *(reinterpret_cast<Leaf*>(inode)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
     auto freePackets = leaf.AddData(offset, size, std::move(data));
     const int added = packetsNumber - static_cast<int>(freePackets.size());
-    auto entry = _cache.find(inode);
-    if (entry != _cache.end()) {
+    auto& shardCache = _cachePerShard.at(ShardForInode(inode));
+    auto entry = shardCache.find(inode);
+    if (entry != shardCache.end()) {
         entry->second += added;
     } else {
-        _cache.insert({ inode, added });
+        shardCache.insert({ inode, added });
     }
-    _totalCachedPackets += added;
+    _grandTotalCachedPackets.fetch_add(added, std::memory_order_relaxed);
 
     return freePackets;
 }
 
-FreeData FileTree::GetFreeData()
+FreeData FileTree::GetFreeData(size_t shardIdx)
 {
-    if (_cache.empty()) {
+    auto& shardCache = _cachePerShard.at(shardIdx);
+    if (shardCache.empty()) {
         return {};
     }
 
-    auto entry = _cache.begin();
+    auto entry = shardCache.begin();
     const fuse_ino_t inode = entry->first;
     auto& leaf = inode == FUSE_ROOT_ID ? GetRoot() : *(reinterpret_cast<Leaf*>(inode)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
     const size_t blockIndex = leaf.GetFirstBlockIndex();
@@ -130,9 +131,9 @@ FreeData FileTree::GetFreeData()
     entry->second -= extracted;
     assert(entry->second >= 0);
     if (entry->second == 0) {
-        _cache.erase(entry);
+        shardCache.erase(entry);
     }
-    _totalCachedPackets -= extracted;
+    _grandTotalCachedPackets.fetch_sub(extracted, std::memory_order_relaxed);
 
     const size_t blockStart = blockIndex * static_cast<size_t>(Leaf::BlockSize);
     const size_t size = static_cast<size_t>(std::min(Leaf::BlockSize, static_cast<ssize_t>(leaf.GetSize()) - static_cast<ssize_t>(blockStart)));
@@ -141,7 +142,7 @@ FreeData FileTree::GetFreeData()
 
 bool FileTree::NeedsEviction() const
 {
-    return _totalCachedPackets > MaxCachePackets;
+    return _grandTotalCachedPackets.load(std::memory_order_relaxed) > MaxCachePackets;
 }
 
 FileCache::FileCache& FileTree::GetFileCache()

--- a/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
@@ -18,7 +18,7 @@
 namespace FastTransport::FileSystem {
 
 FileTree::FileTree(std::filesystem::path&& name, std::filesystem::path&& cacheFolder)
-    : _root(std::make_unique<Leaf>(std::move(name), std::filesystem::file_type::directory, 0, nullptr))
+    : _root(std::make_shared<Leaf>(std::move(name), std::filesystem::file_type::directory, 0, nullptr))
     , _cacheFolder(std::move(cacheFolder))
     , _fileCache(std::make_unique<FileCache::FileCache>())
 {
@@ -55,7 +55,25 @@ FileTree& FileTree::operator=(FileTree&& that) noexcept
     return *this;
 }
 
-FileTree::~FileTree() = default;
+FileTree::~FileTree()
+{
+    // Safety net for shutdown: if FUSE forgets arrived after the scheduler
+    // was already torn down, their ReleaseLeafRefJobs never ran and the
+    // matching _selfPin'd Leaves would still hold themselves alive. Walk
+    // the tree and force the pins down so the cascading shared_ptr
+    // destruction frees everything.
+    if (_root != nullptr) {
+        _root->DropPinsRecursively();
+    }
+}
+
+void FileTree::SetRoot(std::shared_ptr<Leaf> root) noexcept
+{
+    _root = std::move(root);
+    if (_root != nullptr) {
+        _root->SetTree(this);
+    }
+}
 
 Leaf& FileTree::GetRoot()
 {
@@ -171,19 +189,21 @@ void FileTree::Scan(const std::filesystem::path& directoryPath, Leaf& root) // N
     }
 }
 
-Leaf* FileTree::FindLeafByServerInode(std::uint64_t serverInode)
+std::shared_ptr<Leaf> FileTree::FindLeafByServerInode(std::uint64_t serverInode)
 {
     if (serverInode == _root->GetServerInode()) {
-        return _root.get();
+        return _root;
     }
     auto entry = _serverInodeIndex.find(serverInode);
     if (entry == _serverInodeIndex.end()) {
         return nullptr;
     }
-    return entry->second;
+    // weak_ptr.lock() returns nullptr if the Leaf has been destroyed without
+    // a matching UnregisterLeaf — defensive against stale index entries.
+    return entry->second.lock();
 }
 
-void FileTree::RegisterLeaf(std::uint64_t serverInode, Leaf* leaf)
+void FileTree::RegisterLeaf(std::uint64_t serverInode, const std::shared_ptr<Leaf>& leaf)
 {
     _serverInodeIndex[serverInode] = leaf;
 }
@@ -191,28 +211,6 @@ void FileTree::RegisterLeaf(std::uint64_t serverInode, Leaf* leaf)
 void FileTree::UnregisterLeaf(std::uint64_t serverInode)
 {
     _serverInodeIndex.erase(serverInode);
-}
-
-void FileTree::Tombstone(std::unique_ptr<Leaf> leaf)
-{
-    const std::lock_guard<std::mutex> lock(_tombstonesMutex);
-    _tombstones.push_back(std::move(leaf));
-}
-
-void FileTree::RemoveTombstone(Leaf* leaf)
-{
-    std::unique_ptr<Leaf> retired;
-    {
-        const std::lock_guard<std::mutex> lock(_tombstonesMutex);
-        auto found = std::ranges::find_if(_tombstones,
-            [leaf](const std::unique_ptr<Leaf>& candidate) { return candidate.get() == leaf; });
-        if (found == _tombstones.end()) {
-            return;
-        }
-        retired = std::move(*found);
-        _tombstones.erase(found);
-    }
-    // retired's destructor runs here, after the mutex is released.
 }
 
 void FileTree::CancelAllPendingJobs()

--- a/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/FileTree.cpp
@@ -193,6 +193,28 @@ void FileTree::UnregisterLeaf(std::uint64_t serverInode)
     _serverInodeIndex.erase(serverInode);
 }
 
+void FileTree::Tombstone(std::unique_ptr<Leaf> leaf)
+{
+    const std::lock_guard<std::mutex> lock(_tombstonesMutex);
+    _tombstones.push_back(std::move(leaf));
+}
+
+void FileTree::RemoveTombstone(Leaf* leaf)
+{
+    std::unique_ptr<Leaf> retired;
+    {
+        const std::lock_guard<std::mutex> lock(_tombstonesMutex);
+        auto found = std::ranges::find_if(_tombstones,
+            [leaf](const std::unique_ptr<Leaf>& candidate) { return candidate.get() == leaf; });
+        if (found == _tombstones.end()) {
+            return;
+        }
+        retired = std::move(*found);
+        _tombstones.erase(found);
+    }
+    // retired's destructor runs here, after the mutex is released.
+}
+
 void FileTree::CancelAllPendingJobs()
 {
     LOGGER() << "Cancelling pending jobs for all leaves";

--- a/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
@@ -206,74 +206,71 @@ Leaf::Data Leaf::AddData(off_t offset, size_t size, Data&& data)
 {
     auto block = _data.find(offset / BlockSize);
     if (block == _data.end()) {
-        std::set<FileCache::Range> blocks;
-        blocks.insert(FileCache::Range(offset, size, std::move(data)));
+        std::set<std::shared_ptr<FileCache::Range>, FileCache::RangePtrLess> blocks;
+        blocks.insert(std::make_shared<FileCache::Range>(offset, size, std::move(data)));
         _data.insert({ offset / BlockSize, std::move(blocks) });
         _piecesStatus->SetStatus(offset / BlockSize, PieceStatus::InCache);
         return {};
     }
 
-    std::set<FileCache::Range>& blocks = block->second;
+    auto& blocks = block->second;
     auto oldData = blocks.upper_bound(FileCache::Range(offset, size, Data {}));
 
-    if (oldData != blocks.end() && oldData->GetOffset() == offset + size) {
+    if (oldData != blocks.end() && (*oldData)->GetOffset() == offset + size) {
         if (oldData != blocks.begin()) {
-            auto node = blocks.extract(oldData);
-            data.splice(std::move(node.value().GetPackets()));
-            auto prevData = oldData;
-            --prevData;
-            if (prevData->GetOffset() + prevData->GetSize() == offset) {
-                auto prevNode = blocks.extract(prevData);
-                prevNode.value().GetPackets().splice(std::move(data));
-                prevNode.value().SetSize(prevNode.value().GetSize() + size + node.value().GetSize());
-                blocks.insert(std::move(prevNode));
+            auto& nextRange = **oldData;
+            data.splice(std::move(nextRange.GetPackets()));
+            auto prevIt = oldData;
+            --prevIt;
+            if ((*prevIt)->GetOffset() + (*prevIt)->GetSize() == offset) {
+                auto& prevRange = **prevIt;
+                prevRange.GetPackets().splice(std::move(data));
+                prevRange.SetSize(prevRange.GetSize() + size + nextRange.GetSize());
+                blocks.erase(oldData);
                 return {};
             }
         }
-        auto node = blocks.extract(oldData);
-        data.splice(std::move(node.value().GetPackets()));
-        node.value().GetPackets() = std::move(data);
-        node.value().SetSize(node.value().GetSize() + size);
-        node.value().SetOffset(offset);
-        blocks.insert(std::move(node));
+        auto& nextRange = **oldData;
+        data.splice(std::move(nextRange.GetPackets()));
+        nextRange.GetPackets() = std::move(data);
+        nextRange.SetSize(nextRange.GetSize() + size);
+        nextRange.SetOffset(offset);
         return {};
     }
 
     if (oldData == blocks.begin()) {
-        blocks.insert(FileCache::Range(offset, size, std::move(data)));
-        if (oldData->GetOffset() >= offset && oldData->GetOffset() + oldData->GetSize() <= offset + size) {
-            auto removedData = blocks.extract(oldData);
-            return std::move(removedData.value().GetPackets());
+        blocks.insert(std::make_shared<FileCache::Range>(offset, size, std::move(data)));
+        if ((*oldData)->GetOffset() >= offset && (*oldData)->GetOffset() + (*oldData)->GetSize() <= offset + size) {
+            auto removedNode = blocks.extract(oldData);
+            return std::move(removedNode.value()->GetPackets());
         }
         return {};
     }
 
     --oldData;
-    if (oldData->GetOffset() <= offset && offset <= oldData->GetOffset() + oldData->GetSize()) {
-        auto node = blocks.extract(oldData);
+    if ((*oldData)->GetOffset() <= offset && offset <= (*oldData)->GetOffset() + (*oldData)->GetSize()) {
+        auto& prevRange = **oldData;
 
-        if (node.value().GetOffset() + node.value().GetSize() == offset) {
-            node.value().GetPackets().splice(std::move(data));
-            node.value().SetSize(node.value().GetSize() + size);
-            blocks.insert(std::move(node));
+        if (prevRange.GetOffset() + prevRange.GetSize() == offset) {
+            prevRange.GetPackets().splice(std::move(data));
+            prevRange.SetSize(prevRange.GetSize() + size);
             return {};
         }
 
-        assert(node.value().GetOffset() + node.value().GetSize() > offset);
+        assert(prevRange.GetOffset() + prevRange.GetSize() > offset);
 
-        const size_t skipSize = node.value().GetOffset() + node.value().GetSize() - offset;
-        if (node.value().GetPackets().size() > 1) {
-            const size_t blockSize = node.value().GetPackets().front()->GetPayload().size();
+        const size_t skipSize = prevRange.GetOffset() + prevRange.GetSize() - offset;
+        if (prevRange.GetPackets().size() > 1) {
+            const size_t blockSize = prevRange.GetPackets().front()->GetPayload().size();
             auto skipData = data.TryGenerate((skipSize + blockSize - 1) / blockSize);
 
-            node.value().GetPackets().splice(std::move(data));
-            node.value().SetSize(node.value().GetSize() + size - skipSize);
-            blocks.insert(std::move(node));
+            prevRange.GetPackets().splice(std::move(data));
+            prevRange.SetSize(prevRange.GetSize() + size - skipSize);
             return skipData;
         }
     }
 
-    blocks.insert(FileCache::Range(offset, size, std::move(data)));
+    blocks.insert(std::make_shared<FileCache::Range>(offset, size, std::move(data)));
     return {};
 }
 
@@ -288,14 +285,11 @@ std::pair<off_t, Leaf::Data> Leaf::ExtractBlock(size_t index)
 
     _piecesStatus->SetStatus(index, PieceStatus::NotFound);
 
-    std::set<FileCache::Range>& ranges = block->second;
+    auto& ranges = block->second;
 
-    const off_t offset = ranges.begin()->GetOffset();
-    for (auto it = ranges.begin(); it != ranges.end();) {
-        auto extractedIt = it;
-        it++;
-        auto range = ranges.extract(extractedIt);
-        extractedData.splice(std::move(range.value().GetPackets()));
+    const off_t offset = (*ranges.begin())->GetOffset();
+    for (auto& range : ranges) {
+        extractedData.splice(std::move(range->GetPackets()));
     }
 
     _data.erase(block);
@@ -310,7 +304,7 @@ size_t Leaf::GetFirstBlockIndex() const
     size_t minIndex = SIZE_MAX;
     for (const auto& [index, ranges] : _data) {
         const bool anyPinned = std::ranges::any_of(ranges,
-            [](const FileCache::Range& range) { return range.IsPinned(); });
+            [](const std::shared_ptr<FileCache::Range>& range) { return range->IsPinned(); });
         if (!anyPinned) {
             minIndex = std::min(minIndex, index);
         }
@@ -321,7 +315,7 @@ size_t Leaf::GetFirstBlockIndex() const
 FileCache::BufferView Leaf::GetData(off_t offset, size_t size) const
 {
     std::vector<FileCache::Span> spans;
-    std::vector<const FileCache::Range*> pinnedRanges;
+    std::vector<std::shared_ptr<const FileCache::Range>> pinnedRanges;
 
     if (std::cmp_greater_equal(offset, _size)) {
         return {};
@@ -334,26 +328,27 @@ FileCache::BufferView Leaf::GetData(off_t offset, size_t size) const
             return { .spans = std::move(spans), .pin = FileCache::RangePin(std::move(pinnedRanges)) };
         }
 
-        const std::set<FileCache::Range>& blocks = block->second;
-        auto data = blocks.upper_bound(FileCache::Range(offset, size, Data {}));
-        if (data == blocks.begin()) {
+        const auto& blocks = block->second;
+        auto dataIt = blocks.upper_bound(FileCache::Range(offset, size, Data {}));
+        if (dataIt == blocks.begin()) {
             return { .spans = std::move(spans), .pin = FileCache::RangePin(std::move(pinnedRanges)) };
         }
 
-        --data;
+        --dataIt;
 
-        if (offset >= data->GetOffset() && offset <= data->GetOffset() + data->GetSize()) {
+        const auto& dataRange = **dataIt;
+        if (offset >= dataRange.GetOffset() && offset <= dataRange.GetOffset() + dataRange.GetSize()) {
             // Pin this range so GetFirstBlockIndex skips it until the job is done.
-            data->Pin();
-            pinnedRanges.push_back(&*data);
+            dataRange.Pin();
+            pinnedRanges.push_back(*dataIt);
 
-            const auto& packets = data->GetPackets();
+            const auto& packets = dataRange.GetPackets();
 
             if (packets.empty()) {
                 throw std::runtime_error("Data not found");
             }
 
-            size_t start = offset - data->GetOffset();
+            size_t start = offset - dataRange.GetOffset();
 
             auto packet = packets.begin();
             while (start >= (*packet)->GetPayload().size()) {

--- a/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
@@ -25,18 +25,51 @@ Leaf::Leaf(std::filesystem::path&& name, std::filesystem::file_type type, uintma
 {
 }
 
-Leaf::Leaf(Leaf&& that) noexcept = default;
+Leaf::Leaf(Leaf&& that) noexcept
+    : _isTombstoned(that._isTombstoned)
+    , children(std::move(that.children))
+    , _name(std::move(that._name))
+    , _type(that._type)
+    , _size(that._size)
+    , _parent(that._parent)
+    , _nlookup(that._nlookup.load(std::memory_order_relaxed))
+    , _serverInode(that._serverInode)
+    , _tree(that._tree)
+    , _data(std::move(that._data))
+    , _piecesStatus(std::move(that._piecesStatus))
+    , _pendingJobs(std::move(that._pendingJobs))
+{
+}
 
-Leaf& Leaf::operator=(Leaf&& that) noexcept = default;
+Leaf& Leaf::operator=(Leaf&& that) noexcept
+{
+    if (this == &that) {
+        return *this;
+    }
+    _isTombstoned = that._isTombstoned;
+    children = std::move(that.children);
+    _name = std::move(that._name);
+    _type = that._type;
+    _size = that._size;
+    _parent = that._parent;
+    _nlookup.store(that._nlookup.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    _serverInode = that._serverInode;
+    _tree = that._tree;
+    _data = std::move(that._data);
+    _piecesStatus = std::move(that._piecesStatus);
+    _pendingJobs = std::move(that._pendingJobs);
+    return *this;
+}
 
 Leaf::~Leaf() = default;
 
 Leaf& Leaf::AddChild(std::filesystem::path&& name, std::filesystem::file_type type, uintmax_t size)
 {
-    Leaf leaf(std::move(name), type, size, this);
-    auto [insertedLeaf, result] = children.insert({ leaf.GetName().native(), std::move(leaf) });
-    Leaf& child = insertedLeaf->second;
-    child._tree = _tree;
+    auto leaf = std::make_unique<Leaf>(std::move(name), type, size, this);
+    leaf->_tree = _tree;
+    Leaf* raw = leaf.get();
+    auto [insertedLeaf, result] = children.insert({ raw->GetName().native(), std::move(leaf) });
+    Leaf& child = *insertedLeaf->second;
     if (_tree != nullptr && result) {
         _tree->RegisterLeaf(child.GetServerInode(), &child);
     }
@@ -45,8 +78,9 @@ Leaf& Leaf::AddChild(std::filesystem::path&& name, std::filesystem::file_type ty
 
 Leaf& Leaf::AddChild(Leaf&& leaf)
 {
-    auto [insertedLeaf, result] = children.insert({ leaf.GetName().native(), std::move(leaf) });
-    Leaf& child = insertedLeaf->second;
+    auto owned = std::make_unique<Leaf>(std::move(leaf));
+    auto [insertedLeaf, result] = children.insert({ owned->GetName().native(), std::move(owned) });
+    Leaf& child = *insertedLeaf->second;
     if (_tree != nullptr && result) {
         // Walk the freshly-spliced subtree, fix up _tree, and register every node.
         std::vector<Leaf*> queue { &child };
@@ -56,7 +90,7 @@ Leaf& Leaf::AddChild(Leaf&& leaf)
             current->_tree = _tree;
             _tree->RegisterLeaf(current->GetServerInode(), current);
             for (auto& [childName, grandchild] : current->children) {
-                queue.push_back(&grandchild);
+                queue.push_back(grandchild.get());
             }
         }
     } else {
@@ -74,17 +108,25 @@ void Leaf::RemoveChild(const std::string& name)
     if (_tree != nullptr) {
         // Unregister the entire subtree before erasing so no stale pointers
         // remain in the index.
-        std::vector<Leaf*> queue { &entry->second };
+        std::vector<Leaf*> queue { entry->second.get() };
         while (!queue.empty()) {
             Leaf* current = queue.back();
             queue.pop_back();
             _tree->UnregisterLeaf(current->GetServerInode());
             for (auto& [childName, grandchild] : current->children) {
-                queue.push_back(&grandchild);
+                queue.push_back(grandchild.get());
             }
         }
     }
+    // If the kernel still holds nlookup references to this Leaf, hand it to
+    // the tree's tombstone list so its address stays valid until the matching
+    // FUSE forget arrives.
+    std::unique_ptr<Leaf> removed = std::move(entry->second);
     children.erase(entry);
+    if (_tree != nullptr && removed->_nlookup.load(std::memory_order_acquire) > 0) {
+        removed->MarkTombstoned();
+        _tree->Tombstone(std::move(removed));
+    }
 }
 
 void Leaf::SetServerInode(std::uint64_t inode)
@@ -120,21 +162,23 @@ bool Leaf::IsDeleted() const
 
 void Leaf::AddRef() const
 {
-    _nlookup++;
+    _nlookup.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void Leaf::ReleaseRef() const
 {
-    assert(_nlookup > 0);
-
-    _nlookup--;
+    Leaf::ReleaseRef(1);
 }
 
 void Leaf::ReleaseRef(uint64_t nlookup) const
 {
-    assert(_nlookup >= nlookup);
-
-    _nlookup -= nlookup;
+    const uint64_t prev = _nlookup.fetch_sub(nlookup, std::memory_order_acq_rel);
+    assert(prev >= nlookup);
+    if (prev == nlookup && _isTombstoned && _tree != nullptr) {
+        // We can't delete `this` while still holding a reference path through
+        // it, but RemoveTombstone is the very last thing we do.
+        _tree->RemoveTombstone(const_cast<Leaf*>(this)); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
 }
 
 void Leaf::Rescan()
@@ -163,7 +207,7 @@ void Leaf::Rescan()
     }
 }
 
-const std::map<std::string, Leaf>& Leaf::GetChildren() const
+const std::map<std::string, std::unique_ptr<Leaf>>& Leaf::GetChildren() const
 {
     return children;
 }
@@ -172,7 +216,7 @@ std::optional<std::reference_wrapper<const Leaf>> Leaf::Find(const std::string& 
 {
     auto file = children.find(name);
     if (file != children.end()) {
-        return file->second;
+        return std::cref(*file->second);
     }
 
     return {};
@@ -184,7 +228,7 @@ Leaf* Leaf::FindChild(const std::string& name)
     if (file == children.end()) {
         return nullptr;
     }
-    return &file->second;
+    return file->second.get();
 }
 
 std::filesystem::path Leaf::GetFullPath() const
@@ -432,7 +476,7 @@ void Leaf::CancelAllPendingJobs()
         }
         current->_pendingJobs.clear();
         for (auto& [name, child] : current->children) {
-            queue.push_back(&child);
+            queue.push_back(child.get());
         }
     }
 }

--- a/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/Leaf.cpp
@@ -25,72 +25,36 @@ Leaf::Leaf(std::filesystem::path&& name, std::filesystem::file_type type, uintma
 {
 }
 
-Leaf::Leaf(Leaf&& that) noexcept
-    : _isTombstoned(that._isTombstoned)
-    , children(std::move(that.children))
-    , _name(std::move(that._name))
-    , _type(that._type)
-    , _size(that._size)
-    , _parent(that._parent)
-    , _nlookup(that._nlookup.load(std::memory_order_relaxed))
-    , _serverInode(that._serverInode)
-    , _tree(that._tree)
-    , _data(std::move(that._data))
-    , _piecesStatus(std::move(that._piecesStatus))
-    , _pendingJobs(std::move(that._pendingJobs))
-{
-}
-
-Leaf& Leaf::operator=(Leaf&& that) noexcept
-{
-    if (this == &that) {
-        return *this;
-    }
-    _isTombstoned = that._isTombstoned;
-    children = std::move(that.children);
-    _name = std::move(that._name);
-    _type = that._type;
-    _size = that._size;
-    _parent = that._parent;
-    _nlookup.store(that._nlookup.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    _serverInode = that._serverInode;
-    _tree = that._tree;
-    _data = std::move(that._data);
-    _piecesStatus = std::move(that._piecesStatus);
-    _pendingJobs = std::move(that._pendingJobs);
-    return *this;
-}
-
 Leaf::~Leaf() = default;
 
 Leaf& Leaf::AddChild(std::filesystem::path&& name, std::filesystem::file_type type, uintmax_t size)
 {
-    auto leaf = std::make_unique<Leaf>(std::move(name), type, size, this);
+    auto leaf = std::make_shared<Leaf>(std::move(name), type, size, this);
     leaf->_tree = _tree;
-    Leaf* raw = leaf.get();
-    auto [insertedLeaf, result] = children.insert({ raw->GetName().native(), std::move(leaf) });
-    Leaf& child = *insertedLeaf->second;
+    auto [insertedLeaf, result] = children.insert({ leaf->GetName().native(), leaf });
+    auto& childPtr = insertedLeaf->second;
+    Leaf& child = *childPtr;
     if (_tree != nullptr && result) {
-        _tree->RegisterLeaf(child.GetServerInode(), &child);
+        _tree->RegisterLeaf(child.GetServerInode(), childPtr);
     }
     return child;
 }
 
-Leaf& Leaf::AddChild(Leaf&& leaf)
+Leaf& Leaf::AddChild(std::shared_ptr<Leaf> leaf)
 {
-    auto owned = std::make_unique<Leaf>(std::move(leaf));
-    auto [insertedLeaf, result] = children.insert({ owned->GetName().native(), std::move(owned) });
-    Leaf& child = *insertedLeaf->second;
+    auto [insertedLeaf, result] = children.insert({ leaf->GetName().native(), std::move(leaf) });
+    auto& rootPtr = insertedLeaf->second;
+    Leaf& child = *rootPtr;
     if (_tree != nullptr && result) {
         // Walk the freshly-spliced subtree, fix up _tree, and register every node.
-        std::vector<Leaf*> queue { &child };
+        std::vector<std::shared_ptr<Leaf>> queue { rootPtr };
         while (!queue.empty()) {
-            Leaf* current = queue.back();
+            auto current = std::move(queue.back());
             queue.pop_back();
             current->_tree = _tree;
             _tree->RegisterLeaf(current->GetServerInode(), current);
             for (auto& [childName, grandchild] : current->children) {
-                queue.push_back(grandchild.get());
+                queue.push_back(grandchild);
             }
         }
     } else {
@@ -118,15 +82,11 @@ void Leaf::RemoveChild(const std::string& name)
             }
         }
     }
-    // If the kernel still holds nlookup references to this Leaf, hand it to
-    // the tree's tombstone list so its address stays valid until the matching
-    // FUSE forget arrives.
-    std::unique_ptr<Leaf> removed = std::move(entry->second);
+    // Drop the parent's shared_ptr. If the kernel still holds nlookup
+    // references (_selfPin set), the Leaf survives until the last ReleaseRef
+    // (routed via FuseForget → ReleaseLeafRefJob) releases the pin. Otherwise
+    // the Leaf is destroyed here.
     children.erase(entry);
-    if (_tree != nullptr && removed->_nlookup.load(std::memory_order_acquire) > 0) {
-        removed->MarkTombstoned();
-        _tree->Tombstone(std::move(removed));
-    }
 }
 
 void Leaf::SetServerInode(std::uint64_t inode)
@@ -136,7 +96,7 @@ void Leaf::SetServerInode(std::uint64_t inode)
     }
     _serverInode = inode;
     if (_tree != nullptr) {
-        _tree->RegisterLeaf(GetServerInode(), this);
+        _tree->RegisterLeaf(GetServerInode(), shared_from_this());
     }
 }
 
@@ -162,7 +122,12 @@ bool Leaf::IsDeleted() const
 
 void Leaf::AddRef() const
 {
-    _nlookup.fetch_add(1, std::memory_order_acq_rel);
+    // Single-thread invariant: only called from _mainQueue worker. The very
+    // first ref captures _selfPin so the Leaf survives any subsequent
+    // RemoveChild that drops the parent's shared_ptr.
+    if (_nlookup.fetch_add(1, std::memory_order_relaxed) == 0) {
+        _selfPin = shared_from_this();
+    }
 }
 
 void Leaf::ReleaseRef() const
@@ -170,14 +135,31 @@ void Leaf::ReleaseRef() const
     Leaf::ReleaseRef(1);
 }
 
+void Leaf::DropPinsRecursively() noexcept
+{
+    // Iterative BFS to avoid recursion (misc-no-recursion).
+    std::vector<Leaf*> queue { this };
+    while (!queue.empty()) {
+        Leaf* current = queue.back();
+        queue.pop_back();
+        current->_selfPin.reset();
+        for (auto& [name, child] : current->children) {
+            queue.push_back(child.get());
+        }
+    }
+}
+
 void Leaf::ReleaseRef(uint64_t nlookup) const
 {
-    const uint64_t prev = _nlookup.fetch_sub(nlookup, std::memory_order_acq_rel);
+    // Single-thread invariant: only called from _mainQueue worker. Resetting
+    // _selfPin may run ~Leaf if it was the last shared_ptr — `released` is
+    // moved out of the field first so the destructor runs after the local
+    // shared_ptr falls out of scope, with no further `this->` access.
+    const uint64_t prev = _nlookup.fetch_sub(nlookup, std::memory_order_relaxed);
     assert(prev >= nlookup);
-    if (prev == nlookup && _isTombstoned && _tree != nullptr) {
-        // We can't delete `this` while still holding a reference path through
-        // it, but RemoveTombstone is the very last thing we do.
-        _tree->RemoveTombstone(const_cast<Leaf*>(this)); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    if (prev == nlookup) {
+        const std::shared_ptr<const Leaf> released = std::move(_selfPin);
+        // released is destroyed here at end of function scope.
     }
 }
 
@@ -207,7 +189,7 @@ void Leaf::Rescan()
     }
 }
 
-const std::map<std::string, std::unique_ptr<Leaf>>& Leaf::GetChildren() const
+const std::map<std::string, std::shared_ptr<Leaf>>& Leaf::GetChildren() const
 {
     return children;
 }
@@ -222,13 +204,13 @@ std::optional<std::reference_wrapper<const Leaf>> Leaf::Find(const std::string& 
     return {};
 }
 
-Leaf* Leaf::FindChild(const std::string& name)
+std::shared_ptr<Leaf> Leaf::FindChild(const std::string& name)
 {
     auto file = children.find(name);
     if (file == children.end()) {
         return nullptr;
     }
-    return file->second.get();
+    return file->second;
 }
 
 std::filesystem::path Leaf::GetFullPath() const
@@ -332,7 +314,7 @@ std::pair<off_t, Leaf::Data> Leaf::ExtractBlock(size_t index)
     auto& ranges = block->second;
 
     const off_t offset = (*ranges.begin())->GetOffset();
-    for (auto& range : ranges) {
+    for (const auto& range : ranges) {
         extractedData.splice(std::move(range->GetPackets()));
     }
 

--- a/SimpleNetworkProtocol/FileSystem/src/NativeFile.cpp
+++ b/SimpleNetworkProtocol/FileSystem/src/NativeFile.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <unistd.h>
 #endif
 
 #include <cassert>

--- a/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/InvalidateCacheLeafJob.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/InvalidateCacheLeafJob.hpp
@@ -1,24 +1,36 @@
 #pragma once
 
 #include <fuse3/fuse_lowlevel.h>
+#include <memory>
 
 #include "CacheTreeJob.hpp"
+
+namespace FastTransport::FileSystem {
+class Leaf;
+} // namespace FastTransport::FileSystem
 
 namespace FastTransport::TaskQueue {
 
 // Clears a Leaf's block cache and notifies the FUSE kernel to evict its page cache.
 // Runs on the _cacheTreeQueue (same thread as all other Leaf data operations) so no
 // mutex is needed on Leaf::_data.
+//
+// Lifetime: holds the Leaf alive via a shared_ptr for the duration of the job —
+// the dispatch hop from _mainQueue to the cacheTreeQueue shard cannot let the
+// Leaf disappear, regardless of whether RemoveChild on _mainQueue drops the
+// parent's shared_ptr in between. This avoids re-querying _serverInodeIndex
+// (which would race with _mainQueue mutations) and avoids touching nlookup
+// (which would force _selfPin into multi-threaded territory).
 class InvalidateCacheLeafJob : public CacheTreeJob {
 public:
-    InvalidateCacheLeafJob(fuse_ino_t clientInode, fuse_ino_t serverInode, fuse_session* session);
+    InvalidateCacheLeafJob(std::shared_ptr<FileSystem::Leaf> leaf, fuse_ino_t clientInode, fuse_session* session);
 
     void ExecuteCachedTree(ITaskScheduler& scheduler, std::stop_token stop, FileTree& tree) override;
     [[nodiscard]] fuse_ino_t GetInode() const noexcept override { return _clientInode; }
 
 private:
+    std::shared_ptr<FileSystem::Leaf> _leaf;
     fuse_ino_t _clientInode;
-    fuse_ino_t _serverInode;
     fuse_session* _session;
 };
 

--- a/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/PinnedFuseBufVec.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/PinnedFuseBufVec.hpp
@@ -11,12 +11,33 @@
 
 namespace FastTransport::FileSystem::FileCache {
 
+// fuse_bufvec is allocated as a flexible array via `new char[]`, so it must be
+// deallocated as `char[]` to keep ASan's new[]/delete[] pairing happy.
+struct FuseBufVecDeleter {
+    void operator()(fuse_bufvec* ptr) const noexcept // NOLINT(fuchsia-overloaded-operator)
+    {
+        delete[] reinterpret_cast<char*>(ptr); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-owning-memory)
+    }
+};
+
+using FuseBufVecPtr = std::unique_ptr<fuse_bufvec, FuseBufVecDeleter>;
+
+// fuse_bufvec is a flexible-array struct (the buf[1] member is really buf[count]),
+// so the entire object must be allocated as a raw byte buffer of the right size and
+// reinterpret-cast back. This helper centralises the cast so callers don't each
+// need their own NOLINT comment.
+[[nodiscard]] inline FuseBufVecPtr AllocateFuseBufVec(std::size_t count)
+{
+    const std::size_t allocSize = sizeof(fuse_bufvec) + ((count > 0 ? count - 1 : 0) * sizeof(fuse_buf));
+    return FuseBufVecPtr(reinterpret_cast<fuse_bufvec*>(new char[allocSize])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+}
+
 // A fuse_bufvec whose buf[i].mem entries point directly into pinned Leaf packet payloads.
 // Keeping both together ensures the pin is always held for exactly the lifetime of the buffer.
 class PinnedFuseBufVec {
 public:
     PinnedFuseBufVec() = default;
-    PinnedFuseBufVec(std::unique_ptr<fuse_bufvec> buf, RangePin rangePin) noexcept
+    PinnedFuseBufVec(FuseBufVecPtr buf, RangePin rangePin) noexcept
         : _bufvec(std::move(buf))
         , _pin(std::move(rangePin))
     {
@@ -28,7 +49,7 @@ public:
     [[nodiscard]] fuse_bufvec* get() const noexcept { return _bufvec.get(); }
 
 private:
-    std::unique_ptr<fuse_bufvec> _bufvec;
+    FuseBufVecPtr _bufvec;
     RangePin _pin;
 };
 
@@ -40,8 +61,7 @@ private:
     if (count == 0) {
         return {};
     }
-    const std::size_t allocSize = sizeof(fuse_bufvec) + ((count - 1) * sizeof(fuse_buf));
-    std::unique_ptr<fuse_bufvec> fvec(reinterpret_cast<fuse_bufvec*>(new char[allocSize])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto fvec = AllocateFuseBufVec(count);
     fvec->count = count;
     fvec->idx = 0;
     fvec->off = 0;

--- a/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/WriteFileCacheJob.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/FileSystem/FileCache/WriteFileCacheJob.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
-#include "ResponseInFuseNetworkJob.hpp"
+#include "CacheTreeJob.hpp"
+#include "IPacket.hpp"
 
 namespace FastTransport::FileCache {
-class WriteFileCacheJob : public TaskQueue::ResponseInFuseNetworkJob {
+class WriteFileCacheJob : public TaskQueue::CacheTreeJob {
 public:
     using Message = Protocol::IPacket::List;
 
     WriteFileCacheJob(fuse_ino_t inode, size_t size, off_t offset, Message&& data);
-    Message ExecuteResponse(TaskQueue::ITaskScheduler& scheduler, std::stop_token stop, FileTree& fileTree) override;
+    void ExecuteCachedTree(TaskQueue::ITaskScheduler& scheduler, std::stop_token stop, FileTree& fileTree) override;
+
+    [[nodiscard]] fuse_ino_t GetInode() const noexcept override { return _inode; }
 
 private:
     fuse_ino_t _inode;

--- a/SimpleNetworkProtocol/Protocol/include/FileSystem/ReleaseLeafRefJob.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/FileSystem/ReleaseLeafRefJob.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <fuse3/fuse_lowlevel.h>
+
+#include "ResponseInFuseNetworkJob.hpp"
+
+namespace FastTransport::TaskQueue {
+
+// Decrements nlookup on the client-side Leaf identified by `clientInode`
+// (= reinterpret_cast<fuse_ino_t>(Leaf*)). Scheduled by RemoteFileSystem's
+// FUSE forget callback so the actual ReleaseRef call runs on _mainQueue
+// rather than on the FUSE worker thread, preserving the single-thread
+// invariant on Leaf::_nlookup / Leaf::_selfPin.
+class ReleaseLeafRefJob : public ResponseInFuseNetworkJob {
+public:
+    ReleaseLeafRefJob(fuse_ino_t clientInode, std::uint64_t nlookup);
+
+    Message ExecuteResponse(ITaskScheduler& scheduler, std::stop_token stop, FileTree& fileTree) override;
+
+private:
+    fuse_ino_t _clientInode;
+    std::uint64_t _nlookup;
+};
+
+} // namespace FastTransport::TaskQueue

--- a/SimpleNetworkProtocol/Protocol/include/FileSystem/ResponseInFuseNetworkJob.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/FileSystem/ResponseInFuseNetworkJob.hpp
@@ -5,11 +5,14 @@
 #include <stop_token>
 
 #include "FileHandle.hpp"
-#include "FileTree.hpp"
 #include "IPacket.hpp"
 #include "Job.hpp"
 #include "Leaf.hpp"
 #include "MessageReader.hpp"
+
+namespace FastTransport::FileSystem {
+class FileTree;
+} // namespace FastTransport::FileSystem
 
 namespace FastTransport::TaskQueue {
 

--- a/SimpleNetworkProtocol/Protocol/include/TaskScheduler.hpp
+++ b/SimpleNetworkProtocol/Protocol/include/TaskScheduler.hpp
@@ -43,7 +43,7 @@ public:
 
 private:
     static constexpr size_t DiskThreadCount = 4;
-    static constexpr size_t CacheTreeThreadCount = 4;
+    static constexpr size_t CacheTreeThreadCount = FileSystem::FileTree::ShardCount;
 
     // Data members must be declared before queues so that queues (and their
     // worker threads) are destroyed first, before the data they access.

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/ApplyBlockCacheJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/ApplyBlockCacheJob.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "FileCache/PinnedFuseBufVec.hpp"
+#include "FileTree.hpp"
 #include "FreeRecvPacketsJob.hpp"
 #include "FuseRequestTracker.hpp"
 #include "ITaskScheduler.hpp"
@@ -57,8 +58,9 @@ void ApplyBlockCacheJob::ExecuteCachedTree(ITaskScheduler& scheduler, std::stop_
         pendingJob->Execute();
     }
 
+    const size_t shardIdx = FileSystem::FileTree::ShardForInode(_inode);
     while (tree.NeedsEviction()) {
-        auto [evictInode, evictOffset, evictSize, evictData] = tree.GetFreeData();
+        auto [evictInode, evictOffset, evictSize, evictData] = tree.GetFreeData(shardIdx);
         if (evictData.empty()) {
             break;
         }

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/InvalidateCacheLeafJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/InvalidateCacheLeafJob.cpp
@@ -9,20 +9,20 @@
 
 namespace FastTransport::TaskQueue {
 
-InvalidateCacheLeafJob::InvalidateCacheLeafJob(fuse_ino_t clientInode, fuse_ino_t serverInode, fuse_session* session)
-    : _clientInode(clientInode)
-    , _serverInode(serverInode)
+InvalidateCacheLeafJob::InvalidateCacheLeafJob(std::shared_ptr<FileSystem::Leaf> leaf, fuse_ino_t clientInode, fuse_session* session)
+    : _leaf(std::move(leaf))
+    , _clientInode(clientInode)
     , _session(session)
 {
 }
 
-void InvalidateCacheLeafJob::ExecuteCachedTree(ITaskScheduler& /*scheduler*/, std::stop_token /*stop*/, FileTree& tree)
+void InvalidateCacheLeafJob::ExecuteCachedTree(ITaskScheduler& /*scheduler*/, std::stop_token /*stop*/, FileTree& /*tree*/)
 {
-    FileSystem::Leaf* leaf = tree.FindLeafByServerInode(_serverInode);
-    if (leaf == nullptr) {
-        return;
-    }
-    leaf->InvalidateDataCache();
+    // _leaf shared_ptr keeps the Leaf alive for the duration of this job,
+    // so RemoveChild on _mainQueue dropping the parent's shared_ptr in the
+    // meantime cannot free us. Touch only the data-cache state which is
+    // shard-affine on this cacheTreeQueue worker.
+    _leaf->InvalidateDataCache();
     if (_session != nullptr) {
         fuse_lowlevel_notify_inval_inode(_session, _clientInode, 0, 0);
     }

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/PrefixDiskReadFileCacheJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/PrefixDiskReadFileCacheJob.cpp
@@ -29,8 +29,7 @@ TaskQueue::DiskJob::Data PrefixDiskReadFileCacheJob::ExecuteDisk(TaskQueue::ITas
     ZoneScopedN("PrefixDiskReadFileCacheJob::ExecuteDisk");
     const std::size_t prefixCount = _prefixData->count;
     const std::size_t totalCount = prefixCount + 1;
-    const std::size_t allocSize = sizeof(fuse_bufvec) + (prefixCount * sizeof(fuse_buf));
-    std::unique_ptr<fuse_bufvec> combined(reinterpret_cast<fuse_bufvec*>(new char[allocSize])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto combined = FileSystem::FileCache::AllocateFuseBufVec(totalCount);
     combined->count = totalCount;
     combined->idx = 0;
     combined->off = 0;

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/ReadFileCacheJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/ReadFileCacheJob.cpp
@@ -54,8 +54,7 @@ TaskQueue::DiskJob::Data ReadFileCacheJob::ExecuteDisk(TaskQueue::ITaskScheduler
     }
     const size_t diskSize = _size - appendTotalSize;
     const std::size_t totalCount = 1 + _appendData->count;
-    const std::size_t allocSize = sizeof(fuse_bufvec) + ((_appendData->count) * sizeof(fuse_buf));
-    std::unique_ptr<fuse_bufvec> combined(reinterpret_cast<fuse_bufvec*>(new char[allocSize])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto combined = FileSystem::FileCache::AllocateFuseBufVec(totalCount);
     combined->count = totalCount;
     combined->idx = 0;
     combined->off = 0;

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/WriteFileCacheJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/FileCache/WriteFileCacheJob.cpp
@@ -21,9 +21,9 @@ WriteFileCacheJob::WriteFileCacheJob(fuse_ino_t inode, size_t size, off_t offset
     assert(!_data.empty());
 }
 
-WriteFileCacheJob::Message WriteFileCacheJob::ExecuteResponse(TaskQueue::ITaskScheduler& scheduler, std::stop_token /*stop*/, FileTree& fileTree)
+void WriteFileCacheJob::ExecuteCachedTree(TaskQueue::ITaskScheduler& scheduler, std::stop_token /*stop*/, FileTree& fileTree)
 {
-    ZoneScopedN("WriteFileCacheJob::ExecuteResponse");
+    ZoneScopedN("WriteFileCacheJob::ExecuteCachedTree");
     TRACER() << "Execute"
              << " inode=" << _inode
              << " size=" << _size
@@ -36,7 +36,6 @@ WriteFileCacheJob::Message WriteFileCacheJob::ExecuteResponse(TaskQueue::ITaskSc
     assert(_size <= Leaf::BlockSize);
     leaf.GetPiecesStatus()->SetStatus(_offset / Leaf::BlockSize, FileSystem::PieceStatus::OnDisk);
     scheduler.ScheduleReadNetworkJob(std::make_unique<TaskQueue::FreeRecvPacketsJob>(std::move(_data)));
-    return {};
 }
 
 } // namespace FastTransport::FileCache

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/NotifyInvalEntryJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/NotifyInvalEntryJob.cpp
@@ -33,7 +33,7 @@ ResponseInFuseNetworkJob::Message NotifyInvalEntryJob::ExecuteResponse(ITaskSche
     const auto eventType = static_cast<FileSystem::WatchEventType>(eventTypeRaw);
     const bool isDir = isDirRaw != 0;
 
-    FileSystem::Leaf* const parentLeaf = fileTree.FindLeafByServerInode(parentServerInode);
+    const auto parentLeaf = fileTree.FindLeafByServerInode(parentServerInode);
     if (parentLeaf != nullptr) {
         if (eventType == FileSystem::WatchEventType::Created || eventType == FileSystem::WatchEventType::MovedTo) {
             const auto fileType = isDir ? std::filesystem::file_type::directory : std::filesystem::file_type::regular;
@@ -43,15 +43,13 @@ ResponseInFuseNetworkJob::Message NotifyInvalEntryJob::ExecuteResponse(ITaskSche
             // otherwise lookup will keep returning ENOENT until the TTL expires.
             fuse_session* const session = RemoteFileSystem::session;
             if (session != nullptr) {
-                const auto parentClientInode = reinterpret_cast<fuse_ino_t>(parentLeaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
-                fuse_lowlevel_notify_inval_entry(session, parentClientInode, name.c_str(), name.size());
+                fuse_lowlevel_notify_inval_entry(session, GetINode(*parentLeaf), name.c_str(), name.size());
             }
         } else if (eventType == FileSystem::WatchEventType::Deleted || eventType == FileSystem::WatchEventType::MovedFrom) {
             parentLeaf->RemoveChild(name);
             fuse_session* const session = RemoteFileSystem::session;
             if (session != nullptr) {
-                const auto parentClientInode = reinterpret_cast<fuse_ino_t>(parentLeaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
-                fuse_lowlevel_notify_inval_entry(session, parentClientInode, name.c_str(), name.size());
+                fuse_lowlevel_notify_inval_entry(session, GetINode(*parentLeaf), name.c_str(), name.size());
             }
         }
     }

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/NotifyInvalInodeJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/NotifyInvalInodeJob.cpp
@@ -18,11 +18,15 @@ ResponseInFuseNetworkJob::Message NotifyInvalInodeJob::ExecuteResponse(ITaskSche
     std::uint64_t serverInode = 0;
     reader >> serverInode;
 
-    const FileSystem::Leaf* const leaf = fileTree.FindLeafByServerInode(serverInode);
+    auto leaf = fileTree.FindLeafByServerInode(serverInode);
     if (leaf != nullptr) {
-        const auto clientInode = reinterpret_cast<fuse_ino_t>(leaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
+        // The job holds the leaf shared_ptr itself — that keeps the Leaf
+        // alive across the dispatch hop to the cacheTreeQueue shard without
+        // needing to touch nlookup/_selfPin (which would force them into
+        // multi-thread access).
+        const auto clientInode = GetINode(*leaf);
         scheduler.ScheduleCacheTreeJob(std::make_unique<InvalidateCacheLeafJob>(
-            clientInode, static_cast<fuse_ino_t>(serverInode), RemoteFileSystem::session));
+            std::move(leaf), clientInode, RemoteFileSystem::session));
     }
 
     return GetFreeReadPackets();

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ReleaseLeafRefJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ReleaseLeafRefJob.cpp
@@ -1,0 +1,22 @@
+#include "ReleaseLeafRefJob.hpp"
+
+#include <stop_token>
+
+#include "Leaf.hpp"
+
+namespace FastTransport::TaskQueue {
+
+ReleaseLeafRefJob::ReleaseLeafRefJob(fuse_ino_t clientInode, std::uint64_t nlookup)
+    : _clientInode(clientInode)
+    , _nlookup(nlookup)
+{
+}
+
+ResponseInFuseNetworkJob::Message ReleaseLeafRefJob::ExecuteResponse(ITaskScheduler& /*scheduler*/, std::stop_token /*stop*/, FileTree& fileTree)
+{
+    auto& leaf = GetLeaf(_clientInode, fileTree);
+    leaf.ReleaseRef(_nlookup);
+    return {};
+}
+
+} // namespace FastTransport::TaskQueue

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/RemoteFileSystem.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/RemoteFileSystem.cpp
@@ -9,6 +9,7 @@
 #include "FuseReadFileJob.hpp"
 #include "FuseRequestTracker.hpp"
 #include "Logger.hpp"
+#include "ReleaseLeafRefJob.hpp"
 #include "RequestForgetMultiJob.hpp"
 #include "RequestGetAttrJob.hpp"
 #include "RequestLookupJob.hpp"
@@ -99,6 +100,11 @@ void RemoteFileSystem::FuseForget(fuse_req_t request, fuse_ino_t inode, std::uin
 
     fuse_forget_data forget = { .ino = inode, .nlookup = nlookup };
     scheduler->Schedule(std::make_unique<RequestForgetMultiJob>(request, std::span(&forget, 1)));
+    // Decrement client-side nlookup on _mainQueue so _selfPin / _orphans get
+    // released alongside the kernel forwarding above. Without this the local
+    // nlookup grows monotonically and orphan Leaves only get freed at
+    // ~FileTree.
+    scheduler->Schedule(std::make_unique<ReleaseLeafRefJob>(inode, nlookup));
 }
 
 void RemoteFileSystem::FuseForgetmulti(fuse_req_t request, size_t count, fuse_forget_data* forgets)
@@ -109,6 +115,11 @@ void RemoteFileSystem::FuseForgetmulti(fuse_req_t request, size_t count, fuse_fo
              << " count: " << count
              << " forgets: " << forgets;
 
+    // Capture the per-inode counts before scheduling RequestForgetMultiJob:
+    // its ctor rewrites forgets[i].ino in place to the server-side inode.
+    for (size_t i = 0; i < count; ++i) {
+        scheduler->Schedule(std::make_unique<ReleaseLeafRefJob>(forgets[i].ino, forgets[i].nlookup)); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    }
     scheduler->Schedule(std::make_unique<RequestForgetMultiJob>(request, std::span(forgets, count)));
 }
 

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseInFuseNetworkJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseInFuseNetworkJob.cpp
@@ -3,6 +3,7 @@
 #include <fuse3/fuse_lowlevel.h>
 #include <memory>
 
+#include "FileTree.hpp"
 #include "ITaskScheduler.hpp"
 #include "Job.hpp"
 

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseLookupInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseLookupInJob.cpp
@@ -63,6 +63,11 @@ ResponseInFuseNetworkJob::Message ResponseLookupInJob::ExecuteResponse(ITaskSche
     entry.ino = reinterpret_cast<fuse_ino_t>(&newLeaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     entry.attr.st_ino = entry.ino;
 
+    // The kernel receives this inode via fuse_reply_entry and will hold a
+    // reference until it sends fuse_forget. Track that ourselves so the Leaf
+    // survives any concurrent RemoveChild (NotifyInvalEntry) until the matching
+    // forget arrives.
+    newLeaf.AddRef();
     FUSE_ASSERT_REPLY(fuse_reply_entry(FUSE_UNTRACK(request), &entry));
 
     return {};

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseLookupInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseLookupInJob.cpp
@@ -50,8 +50,8 @@ ResponseInFuseNetworkJob::Message ResponseLookupInJob::ExecuteResponse(ITaskSche
     const std::filesystem::file_type type = S_ISDIR(entry.attr.st_mode) ? std::filesystem::file_type::directory : std::filesystem::file_type::regular;
     const uintmax_t size = entry.attr.st_size;
 
-    FileSystem::Leaf* parentLeaf = parentId == FUSE_ROOT_ID
-        ? &fileTree.GetRoot()
+    const auto parentLeaf = parentId == FUSE_ROOT_ID
+        ? fileTree.GetRoot().shared_from_this()
         : fileTree.FindLeafByServerInode(parentId);
     if (parentLeaf == nullptr) {
         FUSE_ASSERT_REPLY(fuse_reply_err(FUSE_UNTRACK(request), ENOENT));
@@ -64,9 +64,9 @@ ResponseInFuseNetworkJob::Message ResponseLookupInJob::ExecuteResponse(ITaskSche
     entry.attr.st_ino = entry.ino;
 
     // The kernel receives this inode via fuse_reply_entry and will hold a
-    // reference until it sends fuse_forget. Track that ourselves so the Leaf
-    // survives any concurrent RemoveChild (NotifyInvalEntry) until the matching
-    // forget arrives.
+    // reference until it sends fuse_forget. Track that locally so the Leaf
+    // survives a later RemoveChild (e.g. via NotifyInvalEntry) that drops
+    // the parent's shared_ptr while the kernel still references the inode.
     newLeaf.AddRef();
     FUSE_ASSERT_REPLY(fuse_reply_entry(FUSE_UNTRACK(request), &entry));
 

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseOpenInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseOpenInJob.cpp
@@ -30,7 +30,7 @@ ResponseInFuseNetworkJob::Message ResponseOpenInJob::ExecuteResponse(ITaskSchedu
 
     fuse_file_info fileInfo {};
     reader >> fileInfo;
-    fileInfo.fh = reinterpret_cast<std::uint64_t>(new FileHandle()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
+    fileInfo.fh = reinterpret_cast<std::uint64_t>(new FileHandle()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-owning-memory)
     reader >> GetFileHandle(&fileInfo).remoteFile;
 
     FUSE_ASSERT_REPLY(fuse_reply_open(FUSE_UNTRACK(request), &fileInfo));

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirInJob.cpp
@@ -6,6 +6,7 @@
 #include <fuse3/fuse_lowlevel.h>
 #include <stop_token>
 
+#include "FileCache/PinnedFuseBufVec.hpp"
 #include "FuseRequestTracker.hpp"
 #include "Logger.hpp"
 
@@ -27,8 +28,7 @@ ResponseInFuseNetworkJob::Message ResponseReadDirInJob::ExecuteResponse(ITaskSch
 
     reader >> data;
 
-    const std::size_t length = sizeof(fuse_bufvec) + (sizeof(fuse_buf) * (data.size() - 1));
-    std::unique_ptr<fuse_bufvec> buffVector(reinterpret_cast<fuse_bufvec*>(new char[length])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto buffVector = FileSystem::FileCache::AllocateFuseBufVec(data.size());
     int index = 0;
 
     buffVector->off = 0;

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirJob.cpp
@@ -60,7 +60,7 @@ ResponseFuseNetworkJob::Message ResponseReadDirJob::ExecuteResponse(std::stop_to
     }
 
     for (off_t i = 0; std::cmp_less(i, size) && child != children.end(); ++i, ++child) {
-        direcotoryWriter.AddDirectoryEntry(child->first, GetINode(child->second), 0, i + 2);
+        direcotoryWriter.AddDirectoryEntry(child->first, GetINode(*child->second), 0, i + 2);
     }
 
     writer << direcotoryWriter.GetWritedPackets();

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusInJob.cpp
@@ -41,6 +41,9 @@ fuse_ino_t ResolveClientInode(std::string_view name, fuse_ino_t parentInode, Fas
         childLeaf = &parentLeaf.AddChild(std::filesystem::path(nameStr), type, entry->entry_out.attr.size);
         childLeaf->SetServerInode(entry->entry_out.nodeid);
     }
+    // Each direntplus entry given to the kernel increments its nlookup; track
+    // that locally so the Leaf survives until the matching forget arrives.
+    childLeaf->AddRef();
     return reinterpret_cast<fuse_ino_t>(childLeaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 }
 

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusInJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusInJob.cpp
@@ -3,12 +3,14 @@
 
 #include <bit>
 #include <cstddef>
+#include <cstring>
 #include <filesystem>
 #include <fuse3/fuse_lowlevel.h>
 #include <linux/fuse.h>
 #include <stop_token>
 #include <sys/stat.h>
 
+#include "FileCache/PinnedFuseBufVec.hpp"
 #include "FuseRequestTracker.hpp"
 #include "Leaf.hpp"
 #include "Logger.hpp"
@@ -17,7 +19,7 @@
 
 namespace {
 
-fuse_ino_t ResolveClientInode(std::string_view name, fuse_ino_t parentInode, FastTransport::FileSystem::Leaf& parentLeaf, const ::fuse_direntplus* entry)
+fuse_ino_t ResolveClientInode(std::string_view name, fuse_ino_t parentInode, FastTransport::FileSystem::Leaf& parentLeaf, const ::fuse_direntplus& entry)
 {
     if (name == ".") {
         return parentInode;
@@ -33,18 +35,19 @@ fuse_ino_t ResolveClientInode(std::string_view name, fuse_ino_t parentInode, Fas
     // kernel-visible inode (= Leaf*) would change between readdirplus calls and
     // invalidate previously handed-out references.
     const std::string nameStr(name);
-    FastTransport::FileSystem::Leaf* childLeaf = parentLeaf.FindChild(nameStr);
-    if (childLeaf == nullptr) {
-        const auto type = (S_ISDIR(entry->entry_out.attr.mode) != 0)
+    auto childLeaf = parentLeaf.FindChild(nameStr);
+    FastTransport::FileSystem::Leaf* childPtr = childLeaf.get();
+    if (childPtr == nullptr) {
+        const auto type = (S_ISDIR(entry.entry_out.attr.mode) != 0)
             ? std::filesystem::file_type::directory
             : std::filesystem::file_type::regular;
-        childLeaf = &parentLeaf.AddChild(std::filesystem::path(nameStr), type, entry->entry_out.attr.size);
-        childLeaf->SetServerInode(entry->entry_out.nodeid);
+        childPtr = &parentLeaf.AddChild(std::filesystem::path(nameStr), type, entry.entry_out.attr.size);
+        childPtr->SetServerInode(entry.entry_out.nodeid);
     }
     // Each direntplus entry given to the kernel increments its nlookup; track
     // that locally so the Leaf survives until the matching forget arrives.
-    childLeaf->AddRef();
-    return reinterpret_cast<fuse_ino_t>(childLeaf); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    childPtr->AddRef();
+    return reinterpret_cast<fuse_ino_t>(childPtr); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 }
 
 // WARNING: This walker decodes the kernel FUSE wire layout (struct fuse_direntplus
@@ -62,17 +65,23 @@ void PopulateTreeAndPatchInodes(fuse_ino_t parentInode, FastTransport::FileSyste
         if (entrySpan.size() < sizeof(::fuse_direntplus)) {
             break;
         }
-        auto* entry = reinterpret_cast<::fuse_direntplus*>(entrySpan.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        const uint32_t namelen = entry->dirent.namelen;
+        // The payload buffer has only byte alignment, so direct field access
+        // through a fuse_direntplus* would be UB. Memcpy through an aligned
+        // local copy to read namelen / patch inode fields.
+        ::fuse_direntplus entry {};
+        std::memcpy(&entry, entrySpan.data(), sizeof(entry));
+        const uint32_t namelen = entry.dirent.namelen;
         if (namelen == 0 || entrySpan.size() < kNameOff + namelen) {
             break;
         }
-        const std::string_view name(entry->dirent.name, namelen); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, hicpp-no-array-decay)
+        const auto nameSpan = entrySpan.subspan(kNameOff, namelen);
+        const std::string_view name(reinterpret_cast<const char*>(nameSpan.data()), nameSpan.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
         const fuse_ino_t localIno = ResolveClientInode(name, parentInode, parentLeaf, entry);
-        entry->entry_out.nodeid = localIno;
-        entry->entry_out.attr.ino = localIno;
-        entry->dirent.ino = localIno;
+        entry.entry_out.nodeid = localIno;
+        entry.entry_out.attr.ino = localIno;
+        entry.dirent.ino = localIno;
+        std::memcpy(entrySpan.data(), &entry, sizeof(entry));
 
         pos += (kNameOff + namelen + (sizeof(uint64_t) - 1)) & ~(sizeof(uint64_t) - 1);
     }
@@ -98,8 +107,7 @@ ResponseInFuseNetworkJob::Message ResponseReadDirPlusInJob::ExecuteResponse(ITas
 
     reader >> data;
 
-    const std::size_t length = sizeof(fuse_bufvec) + (sizeof(fuse_buf) * (data.size() - 1));
-    std::unique_ptr<fuse_bufvec> buffVector(reinterpret_cast<fuse_bufvec*>(new char[length])); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto buffVector = FileSystem::FileCache::AllocateFuseBufVec(data.size());
     buffVector->off = 0;
     buffVector->idx = 0;
     buffVector->count = data.size();

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReadDirPlusJob.cpp
@@ -71,15 +71,15 @@ ResponseFuseNetworkJob::Message ResponseReadDirPlusJob::ExecuteResponse(std::sto
     }
 
     for (; child != children.end() && writedSize + direcotoryWriter.GetEntryPlusSize(child->first) < size; ++inodeIndex, ++child) {
-        if (child->second.IsDeleted()) {
+        if (child->second->IsDeleted()) {
             continue;
         }
 
         struct stat stbuf {};
-        stat(child->second.GetFullPath().c_str(), &stbuf);
-        stbuf.st_ino = GetINode(child->second);
+        stat(child->second->GetFullPath().c_str(), &stbuf);
+        stbuf.st_ino = GetINode(*child->second);
         writedSize += direcotoryWriter.AddDirectoryEntryPlus(child->first, &stbuf, inodeIndex);
-        child->second.AddRef();
+        child->second->AddRef();
     }
 
     writer << direcotoryWriter.GetWritedPackets();

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReleaseJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReleaseJob.cpp
@@ -3,6 +3,7 @@
 
 #include <fuse3/fuse_lowlevel.h>
 #include <stop_token>
+#include <unistd.h>
 
 #include "FileHandle.hpp"
 #include "Logger.hpp"

--- a/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReleaseJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/FileSystem/ResponseReleaseJob.cpp
@@ -3,11 +3,11 @@
 
 #include <fuse3/fuse_lowlevel.h>
 #include <stop_token>
-#include <unistd.h>
 
 #include "FileHandle.hpp"
 #include "Logger.hpp"
 #include "MessageType.hpp"
+#include "RemoteFileHandle.hpp"
 
 #define TRACER() LOGGER() << "[ResponseReleaseJob] " // NOLINT(cppcoreguidelines-macro-usage)
 
@@ -21,17 +21,17 @@ ResponseFuseNetworkJob::Message ResponseReleaseJob::ExecuteResponse(std::stop_to
     auto& reader = GetReader();
     fuse_req_t request = nullptr;
     fuse_ino_t inode = 0;
-    int file = 0;
+    FileSystem::RemoteFileHandle* remoteFile = nullptr;
     const FileSystem::FileHandle* handle = nullptr;
     reader >> request;
     reader >> inode;
-    reader >> file;
+    reader >> remoteFile;
     reader >> handle;
 
     writer << MessageType::ResponseRelease;
     writer << request;
 
-    int error = 0;
+    const int error = 0;
 
     auto& leaf = GetLeaf(inode, fileTree);
     leaf.ReleaseRef();
@@ -43,9 +43,9 @@ ResponseFuseNetworkJob::Message ResponseReleaseJob::ExecuteResponse(std::stop_to
         return {};
     }
 
-    if (close(file) == -1) {
-        error = errno;
-    }
+    // Owning RemoteFileHandle was created by ResponseOpenJob; closing it here
+    // releases the underlying file descriptor through ~NativeFile.
+    delete remoteFile; // NOLINT(cppcoreguidelines-owning-memory)
 
     writer << error;
     writer << handle;

--- a/SimpleNetworkProtocol/Protocol/src/MergeIn.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/MergeIn.cpp
@@ -37,8 +37,8 @@ void MergeIn::ExecuteMainRead(std::stop_token /*stop*/, ITaskScheduler& schedule
     Protocol::MessageReader reader(std::move(_reader));
     FileSystem::InputByteStream<Protocol::MessageReader> input(reader);
 
-    FileSystem::Leaf root = FileSystem::LeafSerializer::Deserialize(input, nullptr);
-    _fileTree.get().GetRoot() = std::move(root); // Possible bug)))
+    auto root = FileSystem::LeafSerializer::Deserialize(input, nullptr);
+    _fileTree.get().SetRoot(std::move(root)); // Possible bug)))
 
     scheduler.Schedule(FreeRecvPacketsJob::Create(_reader.GetPackets()));
 }

--- a/SimpleNetworkProtocol/Protocol/src/ProcessInotifyEventJob.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/ProcessInotifyEventJob.cpp
@@ -36,11 +36,11 @@ namespace {
             return node;
         }
         for (const auto& part : rel) {
-            FileSystem::Leaf* const child = node->FindChild(part.string());
+            auto child = node->FindChild(part.string());
             if (child == nullptr) {
                 return nullptr;
             }
-            node = child;
+            node = child.get();
         }
         return node;
     }

--- a/SimpleNetworkProtocol/Protocol/src/TaskScheduler.cpp
+++ b/SimpleNetworkProtocol/Protocol/src/TaskScheduler.cpp
@@ -256,7 +256,7 @@ void TaskScheduler::ScheduleResponseInFuseNetworkJob(std::unique_ptr<ResponseInF
 
 void TaskScheduler::ScheduleCacheTreeJob(std::unique_ptr<CacheTreeJob>&& job)
 {
-    const size_t idx = std::hash<fuse_ino_t> {}(job->GetInode()) % CacheTreeThreadCount;
+    const size_t idx = FileSystem::FileTree::ShardForInode(job->GetInode());
     _cacheTreeQueues.at(idx).Async([job = std::move(job), this](std::stop_token stop) mutable {
         ZoneScopedN("TaskScheduler::ScheduleCacheTreeJob");
         job->ExecuteCachedTree(*this, stop, _fileTree);

--- a/SimpleNetworkProtocol/SimpleNetworkProtocolLib/include/HeaderBuffer.hpp
+++ b/SimpleNetworkProtocol/SimpleNetworkProtocolLib/include/HeaderBuffer.hpp
@@ -151,7 +151,9 @@ public:
     void SetPayload(std::span<const PayloadType> payload)
     {
         Header(_start, _size).SetPayloadSize(payload.size());
-        std::memcpy(std::next(_start, HeaderSize), payload.data(), payload.size());
+        if (!payload.empty()) {
+            std::memcpy(std::next(_start, HeaderSize), payload.data(), payload.size());
+        }
     }
 
     void SetPayloadSize(std::size_t size)

--- a/SimpleNetworkProtocol/SimpleNetworkProtocolLib/include/HeaderBuffer.hpp
+++ b/SimpleNetworkProtocol/SimpleNetworkProtocolLib/include/HeaderBuffer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cstddef"
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <span>

--- a/SimpleNetworkProtocol/test/ConnectionWriterTest.cpp
+++ b/SimpleNetworkProtocol/test/ConnectionWriterTest.cpp
@@ -159,12 +159,13 @@ TEST(ConnectionWriter, WriteIPacketList)
                     return freePackets;
                 });
 
-        ConnectionWriter writer(stop, connection);
-
         std::array<std::byte, 1000> testData {};
         for (auto& byte : testData) {
             byte = std::byte { 64 };
         }
+
+        ConnectionWriter writer(stop, connection);
+
         IPacket::List sendPackets;
         sendPackets.push_back(std::make_unique<Packet>(1200));
         sendPackets.back()->SetPayload(testData);

--- a/SimpleNetworkProtocol/test/FileCacheTest.cpp
+++ b/SimpleNetworkProtocol/test/FileCacheTest.cpp
@@ -106,8 +106,10 @@ TEST(FileTreeCacheTest, NeedsEvictionTrueOverLimit)
 TEST(FileTreeCacheTest, GetFreeDataEmptyWhenNoCachedData)
 {
     FileTree tree("/tmp/test_cache_tree", "/tmp/test_cache_tree/cache");
-    auto freeData = tree.GetFreeData();
-    EXPECT_EQ(freeData.data.size(), 0);
+    for (size_t shard = 0; shard < FileTree::ShardCount; ++shard) {
+        auto freeData = tree.GetFreeData(shard);
+        EXPECT_EQ(freeData.data.size(), 0);
+    }
 }
 
 TEST(FileTreeCacheTest, GetFreeDataDecrementsUntilUnderLimit)
@@ -125,7 +127,7 @@ TEST(FileTreeCacheTest, GetFreeDataDecrementsUntilUnderLimit)
     ASSERT_TRUE(tree.NeedsEviction());
 
     while (tree.NeedsEviction()) {
-        auto freeData = tree.GetFreeData();
+        auto freeData = tree.GetFreeData(FileTree::ShardForInode(inode));
         if (freeData.data.empty()) {
             break;
         }
@@ -146,7 +148,7 @@ TEST(FileTreeCacheTest, GetFreeDataSetsStatusNotFound)
     auto piecesStatus = file.GetPiecesStatus();
     EXPECT_EQ(piecesStatus->GetStatus(0), PieceStatus::InCache);
 
-    tree.GetFreeData();
+    tree.GetFreeData(FileTree::ShardForInode(inode));
 
     EXPECT_EQ(piecesStatus->GetStatus(0), PieceStatus::NotFound);
 }
@@ -160,7 +162,7 @@ TEST(FileTreeCacheTest, GetFreeDataSetsCorrectSizeForFullBlock)
     auto data = MakePackets(100, 0);
     tree.AddData(inode, 0, 100ULL * 1400, std::move(data));
 
-    auto freeData = tree.GetFreeData();
+    auto freeData = tree.GetFreeData(FileTree::ShardForInode(inode));
     ASSERT_GT(freeData.data.size(), 0);
     EXPECT_EQ(freeData.size, static_cast<size_t>(Leaf::BlockSize));
 }
@@ -178,7 +180,7 @@ TEST(FileTreeCacheTest, GetFreeDataSetsCorrectSizeForLastBlock)
     const off_t lastBlockOffset = Leaf::BlockSize;
     tree.AddData(inode, lastBlockOffset, LastBlockBytes, std::move(data));
 
-    auto freeData = tree.GetFreeData();
+    auto freeData = tree.GetFreeData(FileTree::ShardForInode(inode));
     ASSERT_GT(freeData.data.size(), 0);
     EXPECT_EQ(freeData.size, LastBlockBytes);
 }
@@ -197,7 +199,7 @@ TEST(FileTreeCacheTest, GetFreeDataEvictsOldestBlock)
     tree.AddData(inode, 2 * Leaf::BlockSize, 1400, std::move(data2));
 
     // GetFreeData should evict block 0 (smallest index)
-    auto freeData = tree.GetFreeData();
+    auto freeData = tree.GetFreeData(FileTree::ShardForInode(inode));
     ASSERT_GT(freeData.data.size(), 0);
     EXPECT_EQ(freeData.offset, 0);
 

--- a/SimpleNetworkProtocol/test/LeafTest.cpp
+++ b/SimpleNetworkProtocol/test/LeafTest.cpp
@@ -51,7 +51,7 @@ void CompareLeaf(const Leaf& left, const Leaf& right) // NOLINT(misc-no-recursio
             break;
         }
 
-        CompareLeaf(child, rightChild->second);
+        CompareLeaf(*child, *rightChild->second);
     }
 }
 

--- a/SimpleNetworkProtocol/test/LeafTest.cpp
+++ b/SimpleNetworkProtocol/test/LeafTest.cpp
@@ -13,18 +13,18 @@ namespace {
 
 using FastTransport::FileSystem::Leaf;
 
-Leaf GetTestLeaf()
+std::shared_ptr<Leaf> GetTestLeaf()
 {
-    Leaf root("test", std::filesystem::file_type::directory, 0, nullptr);
+    auto root = std::make_shared<Leaf>("test", std::filesystem::file_type::directory, 0, nullptr);
 
-    root.AddChild(
+    root->AddChild(
             "folder1",
             std::filesystem::file_type::directory, 0)
         .AddChild(
             "file1",
             std::filesystem::file_type::regular, 100);
 
-    Leaf& folder2 = root.AddChild(
+    Leaf& folder2 = root->AddChild(
         "folder2",
         std::filesystem::file_type::directory, 0);
 
@@ -80,17 +80,17 @@ namespace FastTransport::FileSystem {
 
 TEST(LeafTest, LeafSerializationTest)
 {
-    const Leaf root = GetTestLeaf();
+    const auto root = GetTestLeaf();
 
     std::basic_stringstream<std::byte> stream;
     OutputByteStream<std::basic_stringstream<std::byte>> out(stream);
 
-    LeafSerializer::Serialize(root, out);
+    LeafSerializer::Serialize(*root, out);
 
     InputByteStream<std::basic_stringstream<std::byte>> input(stream);
-    const Leaf deserializedRoot = LeafSerializer::Deserialize(input, nullptr);
+    const auto deserializedRoot = LeafSerializer::Deserialize(input, nullptr);
 
-    CompareLeaf(root, deserializedRoot);
+    CompareLeaf(*root, *deserializedRoot);
 }
 
 TEST(LeafTest, LeafGetDataTest)
@@ -333,7 +333,7 @@ TEST(LeafTest, LeafAddDifferentRangeDataTest3)
 TEST(LeafTest, LeafAddIntersectionDataTest)
 {
     return;
-    Leaf root = GetTestLeaf();
+    Leaf root("test", std::filesystem::file_type::regular, 1024L * 1024, nullptr);
 
     Protocol::IPacket::List data;
     constexpr size_t PacketSize = 1300;

--- a/SimpleNetworkProtocol/test/NotifyInvalEntryJobTest.cpp
+++ b/SimpleNetworkProtocol/test/NotifyInvalEntryJobTest.cpp
@@ -89,7 +89,7 @@ TEST(NotifyInvalEntryJobTest, CreateAddsChildToFileTree)
 
     const auto& children = parentDir.GetChildren();
     EXPECT_EQ(children.count("newfile"), 1U);
-    const Leaf& newLeaf = children.at("newfile");
+    const Leaf& newLeaf = *children.at("newfile");
     EXPECT_EQ(newLeaf.GetType(), std::filesystem::file_type::regular);
     EXPECT_EQ(newLeaf.GetSize(), 100U);
     EXPECT_EQ(newLeaf.GetServerInode(), NewServerInode);
@@ -130,8 +130,8 @@ TEST(NotifyInvalEntryJobTest, CreateDirectoryAddsDirectoryLeaf)
 
     const auto& children = parentDir.GetChildren();
     EXPECT_EQ(children.count("newdir"), 1U);
-    EXPECT_EQ(children.at("newdir").GetType(), std::filesystem::file_type::directory);
-    EXPECT_EQ(children.at("newdir").GetServerInode(), NewDirServerInode);
+    EXPECT_EQ(children.at("newdir")->GetType(), std::filesystem::file_type::directory);
+    EXPECT_EQ(children.at("newdir")->GetServerInode(), NewDirServerInode);
 }
 
 } // namespace

--- a/SimpleNetworkProtocol/test/RemoteFileSystemTest.cpp
+++ b/SimpleNetworkProtocol/test/RemoteFileSystemTest.cpp
@@ -975,4 +975,149 @@ TEST(RemoteFileSystemTest, NotifyInvalInodeOnFileModify) // NOLINT(readability-f
     EXPECT_TRUE(testResult) << "Modified file content was not visible via FUSE mount within timeout";
 }
 
+// Functional repro for the kernel-pinned-Leaf lifetime race: real server +
+// client + FUSE mount. The server churns files in a watched directory;
+// InotifyWatcherJob propagates each delete via NotifyInvalEntry →
+// Leaf::RemoveChild on the client. In parallel, a reader process opens/stats
+// entries on the mount, which drives fuse_lookup → Leaf::AddRef.
+//
+// Originally this exercised a UAF where RemoveChild dropped a Leaf still
+// referenced by the kernel; the current ownership model (shared_ptr children
+// map + _selfPin captured by the first AddRef) keeps the Leaf alive across
+// the gap. The test stays in the suite as a regression guard — TSan must see
+// no race on Leaf state across the lookup/RemoveChild interleaving, and ASan
+// must report no leaks (the dtor's DropPinsRecursively breaks any leftover
+// self-reference cycles).
+namespace {
+
+constexpr uint16_t ServerPort7 = 32300;
+constexpr uint16_t ClientPort7 = 32400;
+constexpr const char* MountPoint7 = "/tmp/mnt_leaf_lifetime";
+constexpr const char* CacheDir7 = "/tmp/leaf_lifetime_cache";
+constexpr const char* ServerRoot7 = "/tmp/leaf_lifetime_server";
+
+constexpr int LeafLifetimeFilesPerRound = 8;
+constexpr int LeafLifetimeRounds = 6;
+constexpr int LeafLifetimeReaderIterations = 80;
+
+bool LeafLifetimeReaderLoop(const std::string& watchedMount)
+{
+    for (int it = 0; it < LeafLifetimeReaderIterations; ++it) {
+        DIR* dir = opendir(watchedMount.c_str());
+        if (dir == nullptr) {
+            continue;
+        }
+        while (struct dirent* dent = readdir(dir)) { // NOLINT(concurrency-mt-unsafe)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+            const std::string_view name(dent->d_name);
+            if (name == "." || name == "..") {
+                continue;
+            }
+            struct stat statBuf {};
+            const std::string fullPath = watchedMount + "/" + std::string(name);
+            stat(fullPath.c_str(), &statBuf);
+        }
+        closedir(dir);
+        std::this_thread::sleep_for(5ms);
+    }
+    return true;
+}
+
+bool LeafLifetimeMutatorLoop(const std::string& watchedServer)
+{
+    for (int round = 0; round < LeafLifetimeRounds; ++round) {
+        for (int i = 0; i < LeafLifetimeFilesPerRound; ++i) {
+            std::ofstream(watchedServer + "/f" + std::to_string(i) + ".txt") << "x";
+        }
+        std::this_thread::sleep_for(20ms);
+        for (int i = 0; i < LeafLifetimeFilesPerRound; ++i) {
+            std::filesystem::remove(watchedServer + "/f" + std::to_string(i) + ".txt");
+        }
+        std::this_thread::sleep_for(20ms);
+    }
+    return true;
+}
+
+bool LeafLifetimeRaceBody(const char* mountPoint)
+{
+    const std::string watchedMount = std::string(mountPoint) + "/watched";
+    const std::string watchedServer = std::string(ServerRoot7) + "/watched";
+
+    // Warmup: ls watched/ so the server records its serverInode (otherwise
+    // NotifyInvalEntry from inotify cannot resolve to a client Leaf and
+    // RemoveChild is never called → no race window opens).
+    jprocess warmup([&watchedMount](jprocess::stop_token /*s*/) -> bool {
+        return CountDirEntries(watchedMount) >= 1;
+    });
+    if (!warmup.join()) {
+        std::cerr << "[test] warmup ls failed\n";
+        return false;
+    }
+
+    // Reader: bounded ls+stat — drives fuse_lookup → AddRef.
+    jprocess reader([&watchedMount](jprocess::stop_token /*s*/) -> bool {
+        return LeafLifetimeReaderLoop(watchedMount);
+    });
+
+    // Mutator: bounded server-side churn — fires inotify → NotifyInvalEntry →
+    // Leaf::RemoveChild on the client _mainQueue.
+    jprocess mutator([&watchedServer](jprocess::stop_token /*s*/) -> bool {
+        return LeafLifetimeMutatorLoop(watchedServer);
+    });
+
+    const bool mutatorOk = mutator.join();
+    const bool readerOk = reader.join();
+    return mutatorOk && readerOk;
+}
+
+} // namespace
+
+TEST(RemoteFileSystemTest, LeafLifetimeRaceUnderChurn)
+{
+    // Bounded reader + bounded mutator (each in its own jprocess) running in
+    // parallel: they self-terminate on iteration count, so by the time `body`
+    // returns no FUSE syscall is in flight on the mount and the standard
+    // RunClientWithNotify teardown (UnmountAt + scheduler.Wait + reset) drains
+    // cleanly — same shape as NotifyInvalEntryOnFileDelete and
+    // ParallelListAndReadFiles which already work in this codebase.
+    std::filesystem::remove_all(ServerRoot7);
+    std::filesystem::create_directories(std::string(ServerRoot7) + "/watched");
+    {
+        std::ofstream(std::string(ServerRoot7) + "/watched/anchor.txt") << "x";
+    }
+    PrepareTestDirectories(MountPoint7, CacheDir7);
+
+    std::atomic<bool> testResult { false };
+    std::stop_source stopSource;
+
+    std::jthread serverThread([](std::stop_token stop) {
+        RunServerWithInotify(stop, ServerPort7, ServerRoot7, CacheDir7);
+    });
+
+    std::this_thread::sleep_for(50ms);
+
+    std::jthread clientThread([&testResult, &stopSource](std::stop_token stop) {
+        RunClientWithNotify(stop, ClientPort7, MountPoint7, CacheDir7, ServerRoot7, stopSource, testResult,
+            [](std::stop_token /*stop*/, FastTransport::FileSystem::FileTree& /*tree*/, const char* mountPoint) -> bool {
+                return LeafLifetimeRaceBody(mountPoint);
+            });
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + 60s;
+    while (!stopSource.stop_requested() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(100ms);
+    }
+    if (!stopSource.stop_requested()) {
+        std::cerr << "[shutdown] leaf-lifetime deadline exceeded\n";
+        stopSource.request_stop();
+        LazyUnmountAt(MountPoint7);
+    }
+    serverThread.request_stop();
+    clientThread.request_stop();
+    clientThread.join();
+    serverThread.join();
+
+    EXPECT_TRUE(testResult) << "LeafLifetime race churn test did not complete cleanly";
+}
+
 #endif // __linux__


### PR DESCRIPTION
Enable UBSan by default in Debug, add opt-in ASan (mutually exclusive with TSan), and ensure the existing TSan CI job actually configures a Debug build so the sanitizer is compiled in.